### PR TITLE
Update tags for subnet dhcp_enable and availability_zone param

### DIFF
--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -24,17 +24,11 @@ type ListOpts struct {
 	//Specifies the network segment on which the subnet resides.
 	CIDR string `json:"cidr"`
 
-	//Specifies the IP address list of DNS servers on the subnet.
-	DnsList []string `json:"dnsList"`
-
 	// Status indicates whether or not a subnet is currently operational.
 	Status string `json:"status"`
 
 	//Specifies the gateway of the subnet.
 	GatewayIP string `json:"gateway_ip"`
-
-	//Specifies whether the DHCP function is enabled for the subnet.
-	EnableDHCP bool `json:"dhcp_enable"`
 
 	//Specifies the IP address of DNS server 1 on the subnet.
 	PRIMARY_DNS string `json:"primary_dns"`
@@ -145,10 +139,10 @@ type CreateOpts struct {
 	CIDR             string   `json:"cidr" required:"true"`
 	DnsList          []string `json:"dnsList,omitempty"`
 	GatewayIP        string   `json:"gateway_ip" required:"true"`
-	EnableDHCP       bool     `json:"dhcp_enable,omitempty"`
+	EnableDHCP       bool     `json:"dhcp_enable" no_default:"y"`
 	PRIMARY_DNS      string   `json:"primary_dns,omitempty"`
 	SECONDARY_DNS    string   `json:"secondary_dns,omitempty"`
-	AvailabilityZone string   `json:"availability_zone"`
+	AvailabilityZone string   `json:"availability_zone,omitempty"`
 	VPC_ID           string   `json:"vpc_id" required:"true"`
 }
 
@@ -188,7 +182,7 @@ type UpdateOptsBuilder interface {
 // UpdateOpts contains the values used when updating a subnets.
 type UpdateOpts struct {
 	Name          string   `json:"name,omitempty"`
-	EnableDHCP    bool     `json:"dhcp_enable,omitempty"`
+	EnableDHCP    bool     `json:"dhcp_enable"`
 	PRIMARY_DNS   string   `json:"primary_dns,omitempty"`
 	SECONDARY_DNS string   `json:"secondary_dns,omitempty"`
 	DnsList       []string `json:"dnsList,omitempty"`

--- a/openstack/networking/v1/subnets/testing/requests_test.go
+++ b/openstack/networking/v1/subnets/testing/requests_test.go
@@ -161,6 +161,7 @@ func TestCreateSubnet(t *testing.T) {
           "name": "test_subnets",
           "cidr": "192.168.0.0/16",
           "gateway_ip": "192.168.0.1",
+		  "dhcp_enable": true,
           "primary_dns": "8.8.8.8",
           "secondary_dns": "8.8.4.4",
           "availability_zone":"eu-de-02",
@@ -206,6 +207,7 @@ func TestCreateSubnet(t *testing.T) {
 		AvailabilityZone: "eu-de-02",
 		VPC_ID:           "3b9740a0-b44d-48f0-84ee-42eb166e54f7",
 		DnsList:          []string{"8.8.8.8", "8.8.4.4"},
+		EnableDHCP:       true,
 	}
 	n, err := subnets.Create(fake.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
@@ -237,7 +239,8 @@ func TestUpdateSubnet(t *testing.T) {
 {
 "subnet":
     {
-    "name": "testsubnet"
+    	"name": "testsubnet",
+		"dhcp_enable": false
     }
 }
 `)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR updates tags for dhcp and availability param in subnet create and update options for better management and updates unit test accordingly. It also removes redundant params from list options for listing subnets.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```


