### PR TITLE
Generate a valid endpoint url if it is not returened in identity serv…

### DIFF
--- a/openstack/testing/endpoint_location_test.go
+++ b/openstack/testing/endpoint_location_test.go
@@ -80,8 +80,28 @@ func TestV2EndpointExact(t *testing.T) {
 	}
 }
 
+func TestV2EndpointExactNonExist(t *testing.T) {
+	expectedURLs := map[golangsdk.Availability]string{
+		golangsdk.AvailabilityPublic:   "https://none.correct.com/",
+		golangsdk.AvailabilityAdmin:    "https://none.correct.com/",
+		golangsdk.AvailabilityInternal: "https://none.correct.com/",
+	}
+
+	for availability, expected := range expectedURLs {
+		actual, err := openstack.V2EndpointURL(&catalog2, golangsdk.EndpointOpts{
+			Type:         "none",
+			Name:         "same",
+			Region:       "same",
+			Availability: availability,
+		})
+		th.AssertNoErr(t, err)
+		th.CheckEquals(t, expected, actual)
+	}
+}
+
 func TestV2EndpointNone(t *testing.T) {
-	_, actual := openstack.V2EndpointURL(&catalog2, golangsdk.EndpointOpts{
+	_, actual := openstack.V2EndpointURL(&tokens2.ServiceCatalog{
+		Entries: []tokens2.CatalogEntry{}}, golangsdk.EndpointOpts{
 		Type:         "nope",
 		Availability: golangsdk.AvailabilityPublic,
 	})
@@ -200,8 +220,28 @@ func TestV3EndpointExact(t *testing.T) {
 	}
 }
 
+func TestV3EndpointExactNonExist(t *testing.T) {
+	expectedURLs := map[golangsdk.Availability]string{
+		golangsdk.AvailabilityPublic:   "https://none.correct.com/",
+		golangsdk.AvailabilityAdmin:    "https://none.correct.com/",
+		golangsdk.AvailabilityInternal: "https://none.correct.com/",
+	}
+
+	for availability, expected := range expectedURLs {
+		actual, err := openstack.V3EndpointURL(&catalog3, golangsdk.EndpointOpts{
+			Type:         "none",
+			Name:         "same",
+			Region:       "same",
+			Availability: availability,
+		})
+		th.AssertNoErr(t, err)
+		th.CheckEquals(t, expected, actual)
+	}
+}
+
 func TestV3EndpointNone(t *testing.T) {
-	_, actual := openstack.V3EndpointURL(&catalog3, golangsdk.EndpointOpts{
+	_, actual := openstack.V3EndpointURL(&tokens3.ServiceCatalog{
+		Entries: []tokens3.CatalogEntry{}}, golangsdk.EndpointOpts{
 		Type:         "nope",
 		Availability: golangsdk.AvailabilityPublic,
 	})


### PR DESCRIPTION
…ice.

case 1:
  'cdn,dns' use same address for all locale
case 2:
  other non existing service will use an valid service endpoint url through replace its service name. e,g: https://vpn.cn-bj.huawei.com   -> https://none.cn-bj.huawei.com

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

