### PR TITLE
Move the projectID part from resource uri to endpoint

### DIFF
--- a/openstack/autoscaling/v1/configurations/urls.go
+++ b/openstack/autoscaling/v1/configurations/urls.go
@@ -7,17 +7,17 @@ import (
 const resourcePath = "scaling_configuration"
 
 func createURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(client.ProjectID, resourcePath)
+	return client.ServiceURL(resourcePath)
 }
 
 func getURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(client.ProjectID, resourcePath, id)
+	return client.ServiceURL(resourcePath, id)
 }
 
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(client.ProjectID, resourcePath, id)
+	return client.ServiceURL(resourcePath, id)
 }
 
 func listURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(client.ProjectID, resourcePath)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/autoscaling/v1/groups/urls.go
+++ b/openstack/autoscaling/v1/groups/urls.go
@@ -9,27 +9,27 @@ import (
 const resourcePath = "scaling_group"
 
 func createURL(c *golangsdk.ServiceClient) string {
-	ur := c.ServiceURL(c.ProjectID, resourcePath)
+	ur := c.ServiceURL(resourcePath)
 	log.Printf("[DEBUG] Create URL is: %#v", ur)
 	return ur
 }
 
 func deleteURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, id)
+	return c.ServiceURL(resourcePath, id)
 }
 
 func getURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, id)
+	return c.ServiceURL(resourcePath, id)
 }
 
 func listURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath)
+	return c.ServiceURL(resourcePath)
 }
 
 func enableURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, id, "action")
+	return c.ServiceURL(resourcePath, id, "action")
 }
 
 func updateURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, id)
+	return c.ServiceURL(resourcePath, id)
 }

--- a/openstack/autoscaling/v1/instances/urls.go
+++ b/openstack/autoscaling/v1/instances/urls.go
@@ -9,17 +9,17 @@ const resourcePath = "scaling_group_instance"
 //getURL will build the querystring by which can be able to query all the instances
 //of group
 func listURL(client *golangsdk.ServiceClient, groupID string) string {
-	return client.ServiceURL(client.ProjectID, resourcePath, groupID, "list")
+	return client.ServiceURL(resourcePath, groupID, "list")
 }
 
 //deleteURL will build the query url by which can be able to delete an instance from
 //the group
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(client.ProjectID, resourcePath, id)
+	return client.ServiceURL(resourcePath, id)
 }
 
 //batchURL will build the query url by which can be able to batch add or delete
 //instances
 func batchURL(client *golangsdk.ServiceClient, groupID string) string {
-	return client.ServiceURL(client.ProjectID, resourcePath, groupID, "action")
+	return client.ServiceURL(resourcePath, groupID, "action")
 }

--- a/openstack/autoscaling/v1/policies/urls.go
+++ b/openstack/autoscaling/v1/policies/urls.go
@@ -9,20 +9,20 @@ const resourcePath = "scaling_policy"
 //createURL will build the rest query url of creation
 //the create url is endpoint/scaling_policy
 func createURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(client.ProjectID, resourcePath)
+	return client.ServiceURL(resourcePath)
 }
 
 //deleteURL will build the url of deletion
 //its pattern is endpoint/scaling_policy/<policy-id>
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(client.ProjectID, resourcePath, id)
+	return client.ServiceURL(resourcePath, id)
 }
 
 //getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(client.ProjectID, resourcePath, id)
+	return client.ServiceURL(resourcePath, id)
 }
 
 func updateURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, id)
+	return c.ServiceURL(resourcePath, id)
 }

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -363,7 +363,12 @@ func NewImageServiceV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOp
 // load balancer service.
 func NewLoadBalancerV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "load-balancer")
-	sc.ResourceBase = sc.Endpoint + "v2.0/"
+	hasProjectID = openstack.ContainsProjectId(sc.Endpoint)
+
+	if !hasProjectID {
+		sc.ResourceBase = sc.Endpoint + "v2.0/" + client.ProjectID + "/"
+	}
+
 	return sc, err
 }
 
@@ -405,6 +410,12 @@ func NewCESClient(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (
 		return nil, err
 	}
 	sc.ResourceBase = sc.Endpoint
+
+	hasProjectID = openstack.ContainsProjectId(sc.Endpoint)
+	if !hasProjectID {
+		sc.ResourceBase = sc.Endpoint + client.ProjectID + "/"
+	}
+
 	return sc, err
 }
 
@@ -426,6 +437,12 @@ func NewComputeV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (
 //auto-scaling service of huawei public cloud
 func NewAutoScalingService(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "as")
+	hasProjectID = openstack.ContainsProjectId(sc.Endpoint)
+
+	if !hasProjectID {
+		sc.ResourceBase = sc.Endpoint + client.ProjectID + "/"
+	}
+
 	return sc, err
 }
 
@@ -437,6 +454,12 @@ func NewKmsKeyV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*
 	sc.Endpoint = sc.Endpoint[:strings.LastIndex(sc.Endpoint, "v2")+3]
 	sc.Endpoint = strings.Replace(sc.Endpoint, "v2", "v1.0", 1)
 	sc.ResourceBase = sc.Endpoint
+
+	hasProjectID = openstack.ContainsProjectId(sc.Endpoint)
+	if !hasProjectID {
+		sc.ResourceBase = sc.Endpoint + client.ProjectID + "/"
+	}
+
 	sc.Type = "kms"
 	return sc, err
 }
@@ -474,7 +497,12 @@ func NewNatV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*gol
 // NewMapReduceV1 creates a ServiceClient that may be used with the v1 MapReduce service.
 func NewMapReduceV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "mrs")
-	sc.ResourceBase = sc.Endpoint + client.ProjectID + "/"
+	hasProjectID = openstack.ContainsProjectId(sc.Endpoint)
+
+	if !hasProjectID {
+		sc.ResourceBase = sc.Endpoint + client.ProjectID + "/"
+	}
+
 	return sc, err
 }
 

--- a/openstack/cloudeyeservice/alarmrule/urls.go
+++ b/openstack/cloudeyeservice/alarmrule/urls.go
@@ -7,13 +7,13 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, rootPath)
+	return c.ServiceURL(rootPath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, id)
+	return c.ServiceURL(rootPath, id)
 }
 
 func actionURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, id, "action")
+	return c.ServiceURL(rootPath, id, "action")
 }

--- a/openstack/kms/v1/keys/urls.go
+++ b/openstack/kms/v1/keys/urls.go
@@ -7,41 +7,41 @@ const (
 )
 
 func getURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "describe-key")
+	return c.ServiceURL(resourcePath, "describe-key")
 }
 
 func createURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "create-key")
+	return c.ServiceURL(resourcePath, "create-key")
 }
 
 func deleteURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "schedule-key-deletion")
+	return c.ServiceURL(resourcePath, "schedule-key-deletion")
 }
 
 func updateAliasURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "update-key-alias")
+	return c.ServiceURL(resourcePath, "update-key-alias")
 }
 
 func updateDesURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "update-key-description")
+	return c.ServiceURL(resourcePath, "update-key-description")
 }
 
 func dataEncryptURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "create-datakey")
+	return c.ServiceURL(resourcePath, "create-datakey")
 }
 
 func encryptDEKURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "encrypt-datakey")
+	return c.ServiceURL(resourcePath, "encrypt-datakey")
 }
 
 func enableKeyURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "enable-key")
+	return c.ServiceURL(resourcePath, "enable-key")
 }
 
 func disableKeyURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "disable-key")
+	return c.ServiceURL(resourcePath, "disable-key")
 }
 
 func listURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "list-keys")
+	return c.ServiceURL(resourcePath, "list-keys")
 }

--- a/openstack/networking/v2/extensions/elb/backendecs/urls.go
+++ b/openstack/networking/v2/extensions/elb/backendecs/urls.go
@@ -9,9 +9,9 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient, lId string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, lId, memberPath)
+	return c.ServiceURL(rootPath, resourcePath, lId, memberPath)
 }
 
 func actionURL(c *golangsdk.ServiceClient, lId string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, lId, memberPath, "action")
+	return c.ServiceURL(rootPath, resourcePath, lId, memberPath, "action")
 }

--- a/openstack/networking/v2/extensions/elb/certificate/urls.go
+++ b/openstack/networking/v2/extensions/elb/certificate/urls.go
@@ -8,9 +8,9 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath)
+	return c.ServiceURL(rootPath, resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, id)
+	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/elb/healthcheck/urls.go
+++ b/openstack/networking/v2/extensions/elb/healthcheck/urls.go
@@ -8,9 +8,9 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath)
+	return c.ServiceURL(rootPath, resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, id)
+	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/elb/listeners/urls.go
+++ b/openstack/networking/v2/extensions/elb/listeners/urls.go
@@ -8,9 +8,9 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath)
+	return c.ServiceURL(rootPath, resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, id)
+	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/elb/loadbalancers/urls.go
+++ b/openstack/networking/v2/extensions/elb/loadbalancers/urls.go
@@ -8,9 +8,9 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath)
+	return c.ServiceURL(rootPath, resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, id)
+	return c.ServiceURL(rootPath, resourcePath, id)
 }

--- a/openstack/networking/v2/extensions/elb/quotas/urls.go
+++ b/openstack/networking/v2/extensions/elb/quotas/urls.go
@@ -8,5 +8,5 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath)
+	return c.ServiceURL(rootPath, resourcePath)
 }


### PR DESCRIPTION
**Move ProjectID from resource uri to endpoint**

now, some of the resources supported to be able to access to are put uri with projectid, however, that doesn't a good way. this PR proposes to move this part into client.go as a part of endpoint. there are two cases should be resolved:
1. if the endpoint url already contains the project id, all we should do is to keep it as it was. use it via appending uri.
2. if the endpoint doesn't contain the project id yet, we should append it if need.

a function need to be added to check whether an endpoint contains the project id or not, please refer to #28 

**Special notes for your reviewer**: @niuzhenguo @zhongjun2 @zengchen1024 

**Release note**:

```release-note
move the project id from resource url.
```

