### PR TITLE
fix panic when retriving the project id

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -222,7 +222,9 @@ func v3auth(client *golangsdk.ProviderClient, endpoint string, opts tokens3.Auth
 	}
 
 	client.TokenID = token.ID
-	client.ProjectID = project.ID
+	if project != nil {
+		client.ProjectID = project.ID
+	}
 
 	if opts.CanReauth() {
 		client.ReauthFunc = func() error {


### PR DESCRIPTION
sometimes it can not get project id when the authentication is scoped to domain not project. so, it can not retrieve the project id directly.