### PR TITLE
Add a new jsonMarsal method

### DIFF
--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -281,7 +281,11 @@ func MockForceDeleteResponse(t *testing.T) {
 	th.Mux.HandleFunc("/volumes/d32019d3-bc6e-4319-9c1d-6722fc136a22/action", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "POST")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
-		th.TestBody(t, r, `{"os-force_delete":""}`)
+		th.TestJSONRequest(t, r, `
+{
+    "os-force_delete": ""
+}
+		`)
 		w.WriteHeader(http.StatusAccepted)
 	})
 }

--- a/provider_client.go
+++ b/provider_client.go
@@ -159,6 +159,14 @@ type RequestOpts struct {
 
 var applicationJSON = "application/json"
 
+func jsonMarshal(t interface{}) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	enc := json.NewEncoder(buffer)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(t)
+	return buffer.Bytes(), err
+}
+
 // Request performs an HTTP request using the ProviderClient's current HTTPClient. An authentication
 // header will automatically be provided.
 func (client *ProviderClient) Request(method, url string, options *RequestOpts) (*http.Response, error) {
@@ -172,7 +180,7 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			panic("Please provide only one of JSONBody or RawBody to golangsdk.Request().")
 		}
 
-		rendered, err := json.Marshal(options.JSONBody)
+		rendered, err := jsonMarshal(options.JSONBody)
 		if err != nil {
 			return nil, err
 		}

--- a/results.go
+++ b/results.go
@@ -53,7 +53,7 @@ func (r Result) ExtractInto(to interface{}) error {
 		return json.NewDecoder(reader).Decode(to)
 	}
 
-	b, err := json.Marshal(r.Body)
+	b, err := jsonMarshal(r.Body)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (r Result) extractIntoPtr(to interface{}, label string) error {
 		return err
 	}
 
-	b, err := json.Marshal(m[label])
+	b, err := jsonMarshal(m[label])
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (r Result) extractIntoPtr(to interface{}, label string) error {
 					// https://play.golang.org/p/NHo3ywlPZli
 					newType := reflect.New(typeOfV).Elem()
 
-					b, err := json.Marshal(v)
+					b, err := jsonMarshal(v)
 					if err != nil {
 						return err
 					}
@@ -260,7 +260,7 @@ func (r HeaderResult) ExtractInto(to interface{}) error {
 		}
 	}
 
-	b, err := json.Marshal(tmpHeaderMap)
+	b, err := jsonMarshal(tmpHeaderMap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This tries to fix the issue that the angle brackets "<" and ">" are
escaped to "\u003c" and "\u003e" with json.Marshal.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

