### PR TITLE
Add VBS Service Management Interfaces

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -715,3 +715,23 @@ func NewCSBSService(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts)
 	sc, err := initClientOpts(client, eo, "data-protect")
 	return sc, err
 }
+
+// NewVBSV2 creates a ServiceClient that may be used to access the VBS service for Orange and Telefonica Cloud.
+func NewVBSV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "vbsv2")
+	return sc, err
+}
+
+// NewOTCVBS creates a ServiceClient that may be used to access the VBS service for OTC Cloud.
+func NewOTCVBS(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "vbs")
+	sc.Endpoint = sc.Endpoint + sc.ProjectID + "/"
+	return sc, err
+}
+
+// NewHwVBS creates a service client that is used for Huawei cloud  for VBS.
+func NewHwVBS(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "compute")
+	sc.Endpoint = strings.Replace(sc.Endpoint, "ecs", "vbs", 1)
+	return sc, err
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -736,16 +736,13 @@ func NewVBSV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*gol
 	return sc, err
 }
 
-// NewOTCVBS creates a ServiceClient that may be used to access the VBS service for OTC Cloud.
-func NewOTCVBS(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "vbs")
-	sc.Endpoint = sc.Endpoint + sc.ProjectID + "/"
-	return sc, err
-}
-
-// NewHwVBS creates a service client that is used for Huawei cloud  for VBS.
-func NewHwVBS(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "compute")
-	sc.Endpoint = strings.Replace(sc.Endpoint, "ecs", "vbs", 1)
+// NewVBS creates a service client that is used for VBS.
+func NewVBS(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "volumev2")
+	if err != nil {
+		return nil, err
+	}
+	sc.Endpoint = strings.Replace(sc.Endpoint, "evs", "vbs", 1)
+	sc.ResourceBase = sc.Endpoint
 	return sc, err
 }

--- a/openstack/vbs/v2/backups/doc.go
+++ b/openstack/vbs/v2/backups/doc.go
@@ -1,0 +1,67 @@
+/*
+Package backups enables management and retrieval of Backups
+VBS service.
+
+Example to List Backups
+
+	listOpts := backups.ListOpts{}
+	allBackups, err := backups.List(vbsClient, listOpts)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, backup := range allBackups {
+		fmt.Printf("%+v\n", backup)
+	}
+
+Example to Get a Backup
+
+   getbackup,err:=backups.Get(vbsClient, "6149e448-dcac-4691-96d9-041e09ef617f").Extract()
+   if err != nil {
+         panic(err)
+		}
+
+   fmt.Println(getbackup)
+
+Example to Create a Backup
+
+	createOpts := backups.CreateOpts{
+		Name:"backup-test",
+		VolumeId:"5024a06e-6990-4f12-9dcc-8fe26b01a710",
+	}
+
+	jobInfo, err := backups.Create(vbsClient, createOpts).ExtractJobResponse()
+	if err != nil {
+		panic(err)
+	}
+
+    err1 := backups.WaitForJobSuccess(client, int(120), jobInfo.JobID)
+	if err1 != nil {
+		panic(err1)
+	}
+
+	Label := "backup_id"
+    entity, err2 := backups.GetJobEntity(client, jobInfo.JobID, Label)
+	fmt.Println(entity)
+	if err2 != nil {
+		panic(err2)
+	}
+
+Example to Delete a Backup
+
+	backupID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+	err := backups.Delete(vbsClient, backupID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Restore a Backup
+
+	restoreOpts := backups.BackupRestoreOpts{VolumeId:"5024a06e-6990-4f12-9dcc-8fe26b01a710"}
+
+	restore,err := backups.CreateBackupRestore(vbsClient,"87566ed6-72cb-4053-aa6e-6f6216b3d507",backup).ExtractBackupRestore()
+	if err != nil {
+		panic(err)
+	}
+*/
+package backups

--- a/openstack/vbs/v2/backups/requests.go
+++ b/openstack/vbs/v2/backups/requests.go
@@ -1,0 +1,178 @@
+package backups
+
+import (
+	"reflect"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the backup attributes you want to see returned.
+type ListOpts struct {
+	Id         string
+	SnapshotId string
+	Name       string `q:"name"`
+	Status     string `q:"status"`
+	Limit      int    `q:"limit"`
+	Offset     int    `q:"offset"`
+	VolumeId   string `q:"volume_id"`
+}
+
+// List returns collection of
+// Backup. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those Backup that are owned by the
+// tenant who submits the request, unless an admin user submits the request.
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Backup, error) {
+	q, err := golangsdk.BuildQueryString(&opts)
+	if err != nil {
+		return nil, err
+	}
+	u := listURL(c) + q.String()
+	pages, err := pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
+		return BackupPage{pagination.LinkedPageBase{PageResult: r}}
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+
+	allBackups, err := ExtractBackups(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	return FilterBackups(allBackups, opts)
+}
+
+func FilterBackups(backup []Backup, opts ListOpts) ([]Backup, error) {
+
+	var refinedBackup []Backup
+	var matched bool
+	m := map[string]interface{}{}
+
+	if opts.Id != "" {
+		m["Id"] = opts.Id
+	}
+	if opts.SnapshotId != "" {
+		m["SnapshotId"] = opts.SnapshotId
+	}
+
+	if len(m) > 0 && len(backup) > 0 {
+		for _, backup := range backup {
+			matched = true
+
+			for key, value := range m {
+				if sVal := getStructField(&backup, key); !(sVal == value) {
+					matched = false
+				}
+			}
+
+			if matched {
+				refinedBackup = append(refinedBackup, backup)
+			}
+		}
+	} else {
+		refinedBackup = backup
+	}
+	return refinedBackup, nil
+}
+
+func getStructField(v *Backup, field string) string {
+	r := reflect.ValueOf(v)
+	f := reflect.Indirect(r).FieldByName(field)
+	return string(f.String())
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToBackupCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new backup.
+type CreateOpts struct {
+	//ID of the disk to be backed up
+	VolumeId string `json:"volume_id" required:"true"`
+	//Snapshot ID of the disk to be backed up
+	SnapshotId string `json:"snapshot_id,omitempty" `
+	//Backup name, which cannot start with autobk
+	Name string `json:"name" required:"true"`
+	//Backup description
+	Description string `json:"description,omitempty"`
+	//List of tags to be configured for the backup resources
+	Tags []Tag `json:"tags,omitempty"`
+}
+
+type Tag struct {
+	//Tag key
+	Key string `json:"key" required:"true"`
+	//Tag value
+	Value string `json:"value" required:"true"`
+}
+
+// ToBackupCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToBackupCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "backup")
+}
+
+// Create will create a new Backup based on the values in CreateOpts. To extract
+// the Backup object from the response, call the ExtractJobResponse method on the
+// JobResult.
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r JobResult) {
+	b, err := opts.ToBackupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, reqOpt)
+	return
+}
+
+// RestoreOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type RestoreOptsBuilder interface {
+	ToRestoreCreateMap() (map[string]interface{}, error)
+}
+
+// BackupRestoreOpts contains all the values needed to create a new backup.
+type BackupRestoreOpts struct {
+	//ID of the disk to be backed up
+	VolumeId string `json:"volume_id" required:"true"`
+}
+
+// ToRestoreCreateMap builds a create request body from BackupRestoreOpts.
+func (opts BackupRestoreOpts) ToRestoreCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "restore")
+}
+
+// CreateBackupRestore will create a new Restore based on the values in BackupRestoreOpts. To extract
+// the BackupRestoreInfo object from the response, call the ExtractBackupRestore method on the
+// CreateResult.
+func CreateBackupRestore(c *golangsdk.ServiceClient, id string, opts RestoreOptsBuilder) (r CreateResult) {
+	b, err := opts.ToRestoreCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(restoreURL(c, id), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular backup based on its unique ID. To extract
+//// the Backup object from the response, call the Extract method on the
+//// GetResult.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// Delete will permanently delete a particular backup based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}

--- a/openstack/vbs/v2/backups/results.go
+++ b/openstack/vbs/v2/backups/results.go
@@ -1,0 +1,159 @@
+package backups
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type Backup struct {
+	//Backup ID
+	Id string `json:"id"`
+	//Backup name
+	Name string `json:"name"`
+	//Backup URL
+	Links []golangsdk.Link `json:"links"`
+	//Backup status
+	Status string `json:"status"`
+	//Backup description
+	Description string `json:"description"`
+	//AvailabilityZone where the backup resides
+	AvailabilityZone string `json:"availability_zone"`
+	//Source volume ID of the backup
+	VolumeId string `json:"volume_id"`
+	//Cause of the backup failure
+	FailReason string `json:"fail_reason"`
+	//Backup size
+	Size int `json:"size"`
+	//Number of objects on OBS for the disk data
+	ObjectCount int `json:"object_count"`
+	//Container of the backup
+	Container string `json:"container"`
+	//Backup creation time
+	CreatedAt time.Time `json:"-"`
+	//ID of the tenant to which the backup belongs
+	TenantId string `json:"os-bak-tenant-attr:tenant_id"`
+	//Backup metadata
+	ServiceMetadata string `json:"service_metadata"`
+	//Time when the backup was updated
+	UpdatedAt time.Time `json:"-"`
+	//Current time
+	DataTimeStamp time.Time `json:"-"`
+	//Whether a dependent backup exists
+	DependentBackups bool `json:"has_dependent_backups"`
+	//ID of the snapshot associated with the backup
+	SnapshotId string `json:"snapshot_id"`
+	//Whether the backup is an incremental backup
+	Incremental bool `json:"is_incremental"`
+}
+
+type BackupRestoreInfo struct {
+	//Backup ID
+	BackupId string `json:"backup_id"`
+	//Volume ID
+	VolumeId string `json:"volume_id"`
+	//Volume name
+	VolumeName string `json:"volume_name"`
+}
+
+// BackupPage is the page returned by a pager when traversing over a
+// collection of Backups.
+type BackupPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of Backups has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r BackupPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []golangsdk.Link `json:"backups_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return golangsdk.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a BackupPage struct is empty.
+func (r BackupPage) IsEmpty() (bool, error) {
+	is, err := ExtractBackups(r)
+	return len(is) == 0, err
+}
+
+// ExtractBackups accepts a Page struct, specifically a BackupPage struct,
+// and extracts the elements into a slice of Backups struct. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractBackups(r pagination.Page) ([]Backup, error) {
+	var s struct {
+		Backups []Backup `json:"backups"`
+	}
+	err := (r.(BackupPage)).ExtractInto(&s)
+	return s.Backups, err
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a backup.
+func (r commonResult) Extract() (*Backup, error) {
+	var s struct {
+		Backup *Backup `json:"backup"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Backup, err
+}
+
+// ExtractBackupRestore is a function that accepts a result and extracts a backup
+func (r commonResult) ExtractBackupRestore() (*BackupRestoreInfo, error) {
+	var s struct {
+		Restore *BackupRestoreInfo `json:"restore"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Restore, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Backup.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Backup.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+// UnmarshalJSON overrides the default, to convert the JSON API response into our Backup struct
+func (r *Backup) UnmarshalJSON(b []byte) error {
+	type tmp Backup
+	var s struct {
+		tmp
+		CreatedAt     golangsdk.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt     golangsdk.JSONRFC3339MilliNoZ `json:"updated_at"`
+		DataTimeStamp golangsdk.JSONRFC3339MilliNoZ `json:"data_timestamp"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Backup(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+	r.DataTimeStamp = time.Time(s.DataTimeStamp)
+
+	return nil
+}

--- a/openstack/vbs/v2/backups/results_job.go
+++ b/openstack/vbs/v2/backups/results_job.go
@@ -43,6 +43,7 @@ func WaitForJobSuccess(client *golangsdk.ServiceClient, secs int, jobID string) 
 
 	jobClient := *client
 	jobClient.Endpoint = strings.Replace(jobClient.Endpoint, "v2", "v1", 1)
+	jobClient.ResourceBase = jobClient.Endpoint
 	return golangsdk.WaitFor(secs, func() (bool, error) {
 		job := new(JobStatus)
 		_, err := jobClient.Get(jobClient.ServiceURL("jobs", jobID), &job, nil)
@@ -66,6 +67,7 @@ func GetJobEntity(client *golangsdk.ServiceClient, jobId string, label string) (
 
 	jobClient := *client
 	jobClient.Endpoint = strings.Replace(jobClient.Endpoint, "v2", "v1", 1)
+	jobClient.ResourceBase = jobClient.Endpoint
 	job := new(JobStatus)
 	_, err := jobClient.Get(jobClient.ServiceURL("jobs", jobId), &job, nil)
 	if err != nil {

--- a/openstack/vbs/v2/backups/results_job.go
+++ b/openstack/vbs/v2/backups/results_job.go
@@ -1,0 +1,82 @@
+package backups
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+type JobResponse struct {
+	JobID string `json:"job_id"`
+}
+
+type JobStatus struct {
+	Status     string            `json:"status"`
+	Entities   map[string]string `json:"entities"`
+	JobID      string            `json:"job_id"`
+	JobType    string            `json:"job_type"`
+	BeginTime  string            `json:"begin_time"`
+	EndTime    string            `json:"end_time"`
+	ErrorCode  string            `json:"error_code"`
+	FailReason string            `json:"fail_reason"`
+	SubJobs    []JobStatus       `json:"sub_jobs"`
+}
+
+type JobResult struct {
+	golangsdk.Result
+}
+
+func (r JobResult) ExtractJobResponse() (*JobResponse, error) {
+	job := new(JobResponse)
+	err := r.ExtractInto(job)
+	return job, err
+}
+
+func (r JobResult) ExtractJobStatus() (*JobStatus, error) {
+	job := new(JobStatus)
+	err := r.ExtractInto(job)
+	return job, err
+}
+
+func WaitForJobSuccess(client *golangsdk.ServiceClient, secs int, jobID string) error {
+
+	jobClient := *client
+	jobClient.Endpoint = strings.Replace(jobClient.Endpoint, "v2", "v1", 1)
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		job := new(JobStatus)
+		_, err := jobClient.Get(jobClient.ServiceURL("jobs", jobID), &job, nil)
+		if err != nil {
+			return false, err
+		}
+
+		if job.Status == "SUCCESS" {
+			return true, nil
+		}
+		if job.Status == "FAIL" {
+			err = fmt.Errorf("Job failed with code %s: %s.\n", job.ErrorCode, job.FailReason)
+			return false, err
+		}
+
+		return false, nil
+	})
+}
+
+func GetJobEntity(client *golangsdk.ServiceClient, jobId string, label string) (interface{}, error) {
+
+	jobClient := *client
+	jobClient.Endpoint = strings.Replace(jobClient.Endpoint, "v2", "v1", 1)
+	job := new(JobStatus)
+	_, err := jobClient.Get(jobClient.ServiceURL("jobs", jobId), &job, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if job.Status == "SUCCESS" {
+		if e := job.Entities[label]; e != "" {
+			return e, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Unexpected conversion error in GetJobEntity.")
+}

--- a/openstack/vbs/v2/backups/testing/fixtures.go
+++ b/openstack/vbs/v2/backups/testing/fixtures.go
@@ -1,0 +1,186 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/backups"
+	fake "github.com/huaweicloud/golangsdk/openstack/vbs/v2/common"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+)
+
+// ListExpected represents the expected object from a List request.
+var ListExpected = []backups.Backup{
+	{
+		Name:             "c2c-test-buckup",
+		Id:               "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+		Status:           "available",
+		ObjectCount:      0,
+		TenantId:         "17fbda95add24720a4038ba4b1c705ed",
+		Container:        "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+		AvailabilityZone: "eu-de-01",
+		DependentBackups: false,
+		SnapshotId:       "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+		VolumeId:         "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+		Incremental:      false,
+		Size:             10,
+		Links: []golangsdk.Link{
+			{
+				Href: "https://vbs.eu-de.otc.t-systems.com/v2/17fbda95add24720a4038ba4b1c705ed/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507",
+				Rel:  "self",
+			},
+			{
+				Href: "https://vbs.eu-de.otc.t-systems.com/17fbda95add24720a4038ba4b1c705ed/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507",
+				Rel:  "bookmark",
+			},
+		},
+	},
+}
+
+// FullListOutput represents the response body from a List request.
+const FullListOutput = `
+{
+    "backups": [
+        {
+            "status": "available",
+            "object_count": 0,
+            "os-bak-tenant-attr:tenant_id": "17fbda95add24720a4038ba4b1c705ed",
+            "container": "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+            "name": "c2c-test-buckup",
+            "links": [
+                {
+                    "href": "https://vbs.eu-de.otc.t-systems.com/v2/17fbda95add24720a4038ba4b1c705ed/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507",
+                    "rel": "self"
+                },
+                {
+                    "href": "https://vbs.eu-de.otc.t-systems.com/17fbda95add24720a4038ba4b1c705ed/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507",
+                    "rel": "bookmark"
+                }
+            ],
+            "availability_zone": "eu-de-01",
+            "has_dependent_backups": false,
+            "snapshot_id": "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+            "volume_id": "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+            "is_incremental": false,
+            "id": "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+            "size": 10
+        }
+	]
+}`
+
+// HandleListSuccessfully creates an HTTP handler at `/backups/detail` on the test handler mux
+// that responds with a `List` response.
+func HandleListSuccessfully(t *testing.T, output string) {
+	th.Mux.HandleFunc("/backups/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, output)
+	})
+}
+
+// getResponse represents the response body from a Get request.
+var getResponse = `{
+    "backup": {
+            "status": "available",
+            "object_count": 0,
+            "os-bak-tenant-attr:tenant_id": "17fbda95add24720a4038ba4b1c705ed",
+            "container": "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+            "name": "c2c-test-buckup",
+            "links": [
+                {
+                    "href": "https://vbs.eu-de.otc.t-systems.com/v2/17fbda95add24720a4038ba4b1c705ed/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507",
+                    "rel": "self"
+                },
+                {
+                    "href": "https://vbs.eu-de.otc.t-systems.com/17fbda95add24720a4038ba4b1c705ed/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507",
+                    "rel": "bookmark"
+                }
+            ],
+            "availability_zone": "eu-de-01",
+            "has_dependent_backups": false,
+            "snapshot_id": "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+            "volume_id": "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+            "is_incremental": false,
+            "id": "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+            "size": 10
+        }
+}`
+
+// HandleGetSuccessfully creates an HTTP handler at `/17fbda95add24720a4038ba4b1c705ed/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507`
+// on the test handler mux that responds with a `Get` response.
+func HandleGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, getResponse)
+	})
+}
+
+// CreateExpected represents the expected object from a Create request.
+var CreateExpected = &backups.JobResponse{
+	JobID: "ff8080826576401e01657b99fc444986",
+}
+
+// CreateOutput represents the response body from a Create request.
+const CreateOutput = `{
+    "job_id": "ff8080826576401e01657b99fc444986"
+}`
+
+// HandleCreateSuccessfully creates an HTTP handler at `/backups` on the test handler mux
+// that responds with a `Create` response.
+func HandleCreateSuccessfully(t *testing.T, output string) {
+	th.Mux.HandleFunc("/cloudbackups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, output)
+	})
+}
+
+// HandleDeleteSuccessfully creates an HTTP handler at `/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507`
+// on the test handler mux that responds with a `Delete` response.
+func HandleDeleteSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+// CreateExpected represents the expected object from a Create request.
+var RestoreExpected = &backups.BackupRestoreInfo{
+	BackupId:   "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+	VolumeName: "c2c-test-disk",
+	VolumeId:   "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+}
+
+// RestoreOutput represents the response body from a Create request.
+const RestoreOutput = `
+{
+    "restore": {
+        "backup_id": "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+        "volume_name": "c2c-test-disk",
+        "volume_id": "5024a06e-6990-4f12-9dcc-8fe26b01a710"
+    }
+}`
+
+// HandleRestoreSuccessfully creates an HTTP handler at `/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507/restore` on the test handler mux
+// that responds with a `Create` response.
+func HandleRestoreSuccessfully(t *testing.T, output string) {
+	th.Mux.HandleFunc("/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507/restore", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, output)
+	})
+}

--- a/openstack/vbs/v2/backups/testing/requests_test.go
+++ b/openstack/vbs/v2/backups/testing/requests_test.go
@@ -1,0 +1,97 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/backups"
+	fake "github.com/huaweicloud/golangsdk/openstack/vbs/v2/common"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+)
+
+func TestListBackup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListSuccessfully(t, FullListOutput)
+
+	actual, err := backups.List(fake.ServiceClient(), backups.ListOpts{})
+	if err != nil {
+		t.Errorf("Failed to extract backups: %v", err)
+	}
+	th.AssertDeepEquals(t, ListExpected, actual)
+	th.AssertNoErr(t, err)
+}
+
+func TestGetBackup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleGetSuccessfully(t)
+
+	s, err := backups.Get(fake.ServiceClient(), "87566ed6-72cb-4053-aa6e-6f6216b3d507").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, s, &backups.Backup{
+		Name:             "c2c-test-buckup",
+		Id:               "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+		Status:           "available",
+		ObjectCount:      0,
+		TenantId:         "17fbda95add24720a4038ba4b1c705ed",
+		Container:        "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+		AvailabilityZone: "eu-de-01",
+		DependentBackups: false,
+		SnapshotId:       "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+		VolumeId:         "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+		Incremental:      false,
+		Size:             10,
+		Links: []golangsdk.Link{
+			{
+				Href: "https://vbs.eu-de.otc.t-systems.com/v2/17fbda95add24720a4038ba4b1c705ed/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507",
+				Rel:  "self",
+			},
+			{
+				Href: "https://vbs.eu-de.otc.t-systems.com/17fbda95add24720a4038ba4b1c705ed/backups/87566ed6-72cb-4053-aa6e-6f6216b3d507",
+				Rel:  "bookmark",
+			},
+		},
+	})
+}
+
+func TestCreateBackup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateSuccessfully(t, CreateOutput)
+
+	createOpts := backups.CreateOpts{
+		Name:     "backup_test",
+		VolumeId: "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+	}
+	actual, err := backups.Create(fake.ServiceClient(), createOpts).ExtractJobResponse()
+	th.AssertNoErr(t, err)
+
+	expected := CreateExpected
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestDeleteBackup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDeleteSuccessfully(t)
+
+	result := backups.Delete(fake.ServiceClient(), "87566ed6-72cb-4053-aa6e-6f6216b3d507")
+	th.AssertNoErr(t, result.Err)
+}
+
+func TestCreateRestore(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleRestoreSuccessfully(t, RestoreOutput)
+
+	restoreOpts := backups.BackupRestoreOpts{
+		VolumeId: "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+	}
+	actual, err := backups.CreateBackupRestore(fake.ServiceClient(), "87566ed6-72cb-4053-aa6e-6f6216b3d507", restoreOpts).ExtractBackupRestore()
+	th.AssertNoErr(t, err)
+
+	expected := RestoreExpected
+	th.AssertDeepEquals(t, expected, actual)
+}

--- a/openstack/vbs/v2/backups/urls.go
+++ b/openstack/vbs/v2/backups/urls.go
@@ -1,0 +1,24 @@
+package backups
+
+import "github.com/huaweicloud/golangsdk"
+
+const (
+	cloudNativeRootPath = "cloudbackups"
+	osNativeRootPath    = "backups"
+)
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(cloudNativeRootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(osNativeRootPath, id)
+}
+
+func listURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(osNativeRootPath, "detail")
+}
+
+func restoreURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(osNativeRootPath, id, "restore")
+}

--- a/openstack/vbs/v2/common/common_tests.go
+++ b/openstack/vbs/v2/common/common_tests.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const TokenID = client.TokenID
+
+func ServiceClient() *golangsdk.ServiceClient {
+	sc := client.ServiceClient()
+	sc.ResourceBase = sc.Endpoint
+	return sc
+}

--- a/openstack/vbs/v2/policies/doc.go
+++ b/openstack/vbs/v2/policies/doc.go
@@ -1,0 +1,40 @@
+package policies
+
+/*
+Package policies enables management and retrieval of backup policies
+VBS service.
+
+Example to List Policies
+
+	listopts := policies.ListOpts{PolicyID:"ef5c5859-a8f4-48cb-869a-dbbc466cd6b6",Frequency:0}
+	list,err := policies.List(client,listopts)
+	if err != nil {
+		panic(err)
+	}
+
+
+Example to Create a Policy
+
+	creatopts := policies.CreateOpts{PolicyName: "Demo_policy", ScheduledPolicy: policies.ScheduledPolicy{StartTime: "12:00", Status: "ON", Frequency: 1, RententionNum: 12, RemainFirstBackup: "Y",}, Tags:[]policies.Tag{{Key:"key",Value:"value"}}}
+	create, err := policies.Create(client, creatopts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Policy
+
+	delete := policies.Delete(client,"c776176d-eb3c-4f48-902a-da3a12c4fea9")
+	if delete.Err != nil {
+		panic(delete.Err)
+	}
+
+Example to Associate a resource to a Policy
+
+	assopts := policies.AssociateOpts{PolicyID:"5b549fad-c4e5-4d7e-83b9-eea366f27017",Resources:[]policies.AssociateResource{{ResourceID:"bdec76de-3cca-46b4-8b71-a333467a1b79",ResourceType:"volume"},{ResourceID:"286b8b84-6640-4f6f-acde-2a58e490f371",ResourceType:"volume"}}}
+	associate,err := policies.Associate(client,assopts).ExtractResource()
+
+Example to disassociate a resource to a Policy
+	disassopts := policies.DisassociateOpts{Resources: []policies.DisassociateResource{{ResourceID: "bdec76de-3cca-46b4-8b71-a333467a1b79"},{ResourceID: "286b8b84-6640-4f6f-acde-2a58e490f371"}}}
+	disassociate,err := policies.Disassociate(client,"5b549fad-c4e5-4d7e-83b9-eea366f27017",disassopts).ExtractResource()
+
+*/

--- a/openstack/vbs/v2/policies/requests.go
+++ b/openstack/vbs/v2/policies/requests.go
@@ -1,0 +1,282 @@
+package policies
+
+import (
+	"reflect"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToPolicyCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains the options for create a Policy. This object is
+// passed to Create(). For more information about these parameters,
+// please refer to the Policy object, or the volume backup service API v2
+// documentation
+type CreateOpts struct {
+	//Backup policy name.It cannot start with default.
+	Name string `json:"backup_policy_name" required:"true"`
+	//Details about the scheduling policy
+	ScheduledPolicy ScheduledPolicy `json:"scheduled_policy" required:"true"`
+	// Tags to be configured for the backup policy
+	Tags []Tag `json:"tags,omitempty"`
+}
+
+//Details about the scheduling policy for create
+type ScheduledPolicy struct {
+	//Start time of the backup job.
+	StartTime string `json:"start_time" required:"true"`
+	//Backup interval (1 to 14 days)
+	Frequency int `json:"frequency,omitempty"`
+	//Number of retained backups, minimum 2.
+	RententionNum int `json:"rentention_num,omitempty"`
+	//Whether to retain the first backup in the current month, possible values Y or N
+	RemainFirstBackup string `json:"remain_first_backup_of_curMonth" required:"true"`
+	//Backup policy status, ON or OFF
+	Status string `json:"status" required:"true"`
+}
+
+type Tag struct {
+	//Tag key. A tag key consists of up to 36 characters
+	Key string `json:"key" required:"true"`
+	//Tag value. A tag value consists of 0 to 43 characters
+	Value string `json:"value" required:"true"`
+}
+
+// ToPolicyCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToPolicyCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new Policy based on the values in CreateOpts. To extract
+// the Policy object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPolicyCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(commonURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToPolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains the options for Update a Policy.
+type UpdateOpts struct {
+	//Backup policy name.It cannot start with default.
+	Name string `json:"backup_policy_name,omitempty"`
+	//Details about the scheduling policy
+	ScheduledPolicy UpdateSchedule `json:"scheduled_policy,omitempty"`
+}
+
+//Details about the scheduling policy for update.
+type UpdateSchedule struct {
+	//Start time of the backup job.
+	StartTime string `json:"start_time,omitempty"`
+	//Backup interval (1 to 14 days)
+	Frequency int `json:"frequency,omitempty"`
+	//Number of retained backups, minimum 2.
+	RententionNum int `json:"rentention_num,omitempty"`
+	//Number of retained backups, minimum 2.
+	RemainFirstBackup string `json:"remain_first_backup_of_curMonth,omitempty"`
+	//Backup policy status, ON or OFF
+	Status string `json:"status,omitempty"`
+}
+
+// ToPolicyUpdateMap assembles a request body based on the contents of a
+// UpdateOpts.
+func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+//Update will Update an existing backup Policy based on the values in UpdateOpts.To extract
+// the Policy object from the response, call the Extract method on the
+// UpdateResult.
+func Update(c *golangsdk.ServiceClient, policyID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+//Delete will delete the specified backup policy.
+func Delete(c *golangsdk.ServiceClient, policyID string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, policyID), nil)
+	return
+}
+
+//ListOpts allows filtering policies
+type ListOpts struct {
+	//Backup policy ID
+	ID string
+	//Backup policy name
+	Name string
+	//Backup policy status
+	Status string
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// Policies. It accepts a ListOpts struct, which allows you to
+// filter the returned collection for greater efficiency.
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Policy, error) {
+
+	pages, err := pagination.NewPager(c, commonURL(c), func(r pagination.PageResult) pagination.Page {
+		return PolicyPage{pagination.LinkedPageBase{PageResult: r}}
+	}).AllPages()
+
+	allPolicies, err := ExtractPolicies(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	return FilterPolicies(allPolicies, opts)
+}
+
+func FilterPolicies(policies []Policy, opts ListOpts) ([]Policy, error) {
+
+	var refinedPolicies []Policy
+	var matched bool
+
+	m := map[string]FilterStruct{}
+
+	if opts.ID != "" {
+		m["ID"] = FilterStruct{Value: opts.ID}
+	}
+	if opts.Name != "" {
+		m["Name"] = FilterStruct{Value: opts.Name}
+	}
+
+	if opts.Status != "" {
+		m["Status"] = FilterStruct{Value: opts.Status, Driller: []string{"ScheduledPolicy"}}
+	}
+
+	if len(m) > 0 && len(policies) > 0 {
+		for _, policies := range policies {
+			matched = true
+
+			for key, value := range m {
+				if sVal := GetStructNestedField(&policies, key, value.Driller); !(sVal == value.Value) {
+					matched = false
+				}
+			}
+			if matched {
+				refinedPolicies = append(refinedPolicies, policies)
+			}
+		}
+	} else {
+		refinedPolicies = policies
+	}
+	return refinedPolicies, nil
+}
+
+func GetStructNestedField(v *Policy, field string, structDriller []string) string {
+	r := reflect.ValueOf(v)
+	for _, drillField := range structDriller {
+		f := reflect.Indirect(r).FieldByName(drillField).Interface()
+		r = reflect.ValueOf(f)
+	}
+	f1 := reflect.Indirect(r).FieldByName(field)
+	return string(f1.String())
+}
+
+type FilterStruct struct {
+	Value   string
+	Driller []string
+}
+
+// AssociateOptsBuilder allows extensions to add additional parameters to the
+// Associate request.
+type AssociateOptsBuilder interface {
+	ToPolicyAssociateMap() (map[string]interface{}, error)
+}
+
+// AssociateOpts contains the options to associate a resource to a Policy.
+type AssociateOpts struct {
+	//Backup policy ID, to which the resource is to be associated.
+	PolicyID string `json:"backup_policy_id" required:"true"`
+	//Details about the resources to associate with the policy.
+	Resources []AssociateResource `json:"resources" required:"true"`
+}
+
+type AssociateResource struct {
+	//The ID of the resource to associate with policy.
+	ResourceID string `json:"resource_id" required:"true"`
+	//Type of the resource , e.g. volume.
+	ResourceType string `json:"resource_type" required:"true"`
+}
+
+// ToPolicyAssociateMap assembles a request body based on the contents of a
+// AssociateOpts.
+func (opts AssociateOpts) ToPolicyAssociateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Associate will associate a resource tp a backup policy based on the values in AssociateOpts. To extract
+// the associated resources from the response, call the ExtractResource method on the
+// ResourceResult.
+func Associate(client *golangsdk.ServiceClient, opts AssociateOpts) (r ResourceResult) {
+	b, err := opts.ToPolicyAssociateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(associateURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// DisassociateOptsBuilder allows extensions to add additional parameters to the
+// Disassociate request.
+type DisassociateOptsBuilder interface {
+	ToPolicyDisassociateMap() (map[string]interface{}, error)
+}
+
+// DisassociateOpts contains the options disassociate a resource from a Policy.
+type DisassociateOpts struct {
+	//Disassociate Resources
+	Resources []DisassociateResource `json:"resources" required:"true"`
+}
+
+type DisassociateResource struct {
+	//ResourceID
+	ResourceID string `json:"resource_id" required:"true"`
+}
+
+// ToPolicyDisassociateMap assembles a request body based on the contents of a
+// DisassociateOpts.
+func (opts DisassociateOpts) ToPolicyDisassociateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Disassociate will disassociate a resource from a backup policy based on the values in DisassociateOpts. To extract
+// the disassociated resources from the response, call the ExtractResource method on the
+// ResourceResult.
+func Disassociate(client *golangsdk.ServiceClient, policyID string, opts DisassociateOpts) (r ResourceResult) {
+	b, err := opts.ToPolicyDisassociateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(disassociateURL(client, policyID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/vbs/v2/policies/results.go
+++ b/openstack/vbs/v2/policies/results.go
@@ -1,0 +1,107 @@
+package policies
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type Policy struct {
+	//Backup policy ID
+	ID string `json:"backup_policy_id"`
+	//Backup policy name
+	Name string `json:"backup_policy_name"`
+	//Details about the scheduling policy
+	ScheduledPolicy ScheduledPolicy `json:"scheduled_policy"`
+	//Number of volumes associated with the backup policy
+	ResourceCount int `json:"policy_resource_count"`
+}
+
+type ResultResources struct {
+	//List of successfully associated/disassociated resources
+	SuccessResources []Resource `json:"success_resources"`
+	//List of the resources that fail to be associated/disassociated
+	FailResources []Resource `json:"fail_resources"`
+}
+
+type Resource struct {
+	//Resource ID
+	ResourceID string `json:"resource_id"`
+	//Resource type
+	ResourceType string `json:"resource_type"`
+	//Availability zone to which the resource belongs
+	AvailabilityZone string `json:"availability_zone"`
+	//POD to which the resource belongs
+	Pod string `json:"os_vol_host_attr"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents the result of a create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation.
+type DeleteResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+// ResourceResult represents the result of a associate/diassociate operation.
+type ResourceResult struct {
+	commonResult
+}
+
+// Extract will get the Policy object from the commonResult
+func (r commonResult) Extract() (*Policy, error) {
+	var response Policy
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type PolicyPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a page contains no Policies results.
+func (r PolicyPage) IsEmpty() (bool, error) {
+	s, err := ExtractPolicies(r)
+	return len(s) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r PolicyPage) NextPageURL() (string, error) {
+	var s struct {
+		Policies []golangsdk.Link `json:"backup_policies_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return golangsdk.ExtractNextURL(s.Policies)
+}
+
+// ExtractPolicies accepts a Page struct, specifically a PolicyPage struct,
+// and extracts the elements into a slice of Policy structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractPolicies(r pagination.Page) ([]Policy, error) {
+	var s struct {
+		Policies []Policy `json:"backup_policies"`
+	}
+	err := (r.(PolicyPage)).ExtractInto(&s)
+	return s.Policies, err
+}
+
+// ExtractResource will get the Association/disassociation of resources from the ResourceResult
+func (r ResourceResult) ExtractResource() (*ResultResources, error) {
+	var response ResultResources
+	err := r.ExtractInto(&response)
+	return &response, err
+}

--- a/openstack/vbs/v2/policies/testing/fixtures.go
+++ b/openstack/vbs/v2/policies/testing/fixtures.go
@@ -1,0 +1,149 @@
+package testing
+
+import "github.com/huaweicloud/golangsdk/openstack/vbs/v2/policies"
+
+const Output = `
+{
+		  "backup_policy_name": "Test_Policy",
+		  "scheduled_policy": {
+		    "frequency": 1,
+		    "remain_first_backup_of_curMonth": "Y",
+		    "rentention_num": 10,
+		    "start_time": "12:00",
+		    "status": "ON"
+		  },
+		  "tags": [
+		    {
+		      "key": "key",
+		      "value": "value"
+		    }
+		  ]
+		}`
+
+const UpdateOutput = `
+{
+    "backup_policy_name": "Test_02",
+    "scheduled_policy" : {
+        "remain_first_backup_of_curMonth" : "Y",
+        "rentention_num" : 10,
+        "frequency" : 1,
+        "start_time" : "10:00",
+        "status" : "ON"
+    }
+}`
+
+const ListOutput = `{
+    "backup_policies" : [
+    {
+        "backup_policy_id" : "ed8b9f73-4415-494d-a54e-5f3373bc353d",
+        "backup_policy_name": "plan01",
+        "scheduled_policy" : {
+            "remain_first_backup_of_curMonth" : "Y",
+            "rentention_num" : 10,
+            "frequency" : 1,
+            "start_time" : "12:00",
+            "status" : "ON"
+        },
+        "policy_resource_count": 0
+    },
+    {
+        "backup_policy_id" : "8dd473c9-5a80-4ad5-862e-492c9af2b6bd",
+        "backup_policy_name": "plan02",
+        "scheduled_policy" : {
+            "remain_first_backup_of_curMonth" : "Y",
+            "rentention_num" : 10,
+            "frequency" : 1,
+            "start_time" : "14:00",
+            "status" : "ON"
+        },
+        "policy_resource_count": 10
+    }]
+}`
+
+const AssociateOutput = `
+{
+    "success_resources": [
+        {
+            "resource_id": "0f187b65-8d0e-4fc0-9096-3b55d330531e",
+            "os_vol_host_attr": "pod01.eu-de-01",
+            "availability_zone": "eu-de-01",
+            "resource_type": "volume"
+        }
+    ], 
+    "fail_resources": [ ]
+}`
+
+const DisssociateOutput = `
+{
+    "success_resources": [
+        {
+            "resource_id": "0f187b65-8d0e-4fc0-9096-3b55d330531e"            
+        }
+    ], 
+    "fail_resources": [ ]
+}`
+
+var ListPolicies = []policies.Policy{
+	{ID: "ed8b9f73-4415-494d-a54e-5f3373bc353d",
+		Name: "plan01",
+		ScheduledPolicy: policies.ScheduledPolicy{
+			Frequency:         1,
+			RemainFirstBackup: "Y",
+			RententionNum:     10,
+			StartTime:         "12:00",
+			Status:            "ON",
+		},
+		ResourceCount: 0,
+	},
+	{ID: "8dd473c9-5a80-4ad5-862e-492c9af2b6bd",
+		Name: "plan02",
+		ScheduledPolicy: policies.ScheduledPolicy{
+			Frequency:         1,
+			RemainFirstBackup: "Y",
+			RententionNum:     10,
+			StartTime:         "14:00",
+			Status:            "ON",
+		},
+		ResourceCount: 10,
+	},
+}
+
+var Update = &policies.Policy{
+	Name: "Test_02",
+	ScheduledPolicy: policies.ScheduledPolicy{
+		Frequency:         1,
+		RemainFirstBackup: "Y",
+		RententionNum:     10,
+		StartTime:         "10:00",
+		Status:            "ON",
+	},
+}
+
+var Expected = &policies.Policy{
+	Name: "Test_Policy",
+	ScheduledPolicy: policies.ScheduledPolicy{
+		Frequency:         1,
+		RemainFirstBackup: "Y",
+		RententionNum:     10,
+		StartTime:         "12:00",
+		Status:            "ON",
+	},
+}
+
+var Associate = &policies.ResultResources{
+	SuccessResources: []policies.Resource{
+		{ResourceID: "0f187b65-8d0e-4fc0-9096-3b55d330531e",
+			ResourceType:     "volume",
+			Pod:              "pod01.eu-de-01",
+			AvailabilityZone: "eu-de-01",
+		},
+	},
+	FailResources: []policies.Resource{},
+}
+
+var Disassociate = &policies.ResultResources{
+	SuccessResources: []policies.Resource{
+		{ResourceID: "0f187b65-8d0e-4fc0-9096-3b55d330531e"},
+	},
+	FailResources: []policies.Resource{},
+}

--- a/openstack/vbs/v2/policies/testing/requests_test.go
+++ b/openstack/vbs/v2/policies/testing/requests_test.go
@@ -1,0 +1,180 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/huaweicloud/golangsdk/openstack/vbs/v2/common"
+	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/policies"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+)
+
+func TestCreateV2Policy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/backuppolicy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Set("Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		th.TestJSONRequest(t, r, `
+{
+    "backup_policy_name": "Test_Policy",
+    "scheduled_policy" : {
+        "remain_first_backup_of_curMonth" : "Y",
+        "rentention_num" : 10,
+        "frequency" : 1,
+        "start_time" : "12:00",
+        "status" : "ON"
+    },
+    "tags":[{
+      "key":"key",
+      "value":"value"
+    }]
+}
+`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, Output)
+	})
+	createOptions := policies.CreateOpts{Name: "Test_Policy", ScheduledPolicy: policies.ScheduledPolicy{StartTime: "12:00", Status: "ON", Frequency: 1, RententionNum: 10, RemainFirstBackup: "Y"}, Tags: []policies.Tag{{Key: "key", Value: "value"}}}
+	actual, err := policies.Create(fake.ServiceClient(), createOptions).Extract()
+	th.AssertNoErr(t, err)
+	expected := Expected
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestUpdateV2Policy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/backuppolicy/af8a20b0-117d-4fc3-ae53-aa3968a4f870", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		th.TestJSONRequest(t, r, `
+{
+    "backup_policy_name": "Test_02",
+    "scheduled_policy" : {
+        "remain_first_backup_of_curMonth" : "Y",
+        "rentention_num" : 10,
+        "frequency" : 1,
+        "start_time" : "10:00",
+        "status" : "ON"
+    }
+}
+`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, UpdateOutput)
+	})
+	updateOptions := policies.UpdateOpts{Name: "Test_02", ScheduledPolicy: policies.UpdateSchedule{StartTime: "10:00", Status: "ON", Frequency: 1, RententionNum: 10, RemainFirstBackup: "Y"}}
+	update, err := policies.Update(fake.ServiceClient(), "af8a20b0-117d-4fc3-ae53-aa3968a4f870", updateOptions).Extract()
+	th.AssertNoErr(t, err)
+	expected := Update
+	th.AssertDeepEquals(t, expected, update)
+}
+
+func TestDeleteV2Policy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/backuppolicy/af8a20b0-117d-4fc3-ae53-aa3968a4f870", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	delete := policies.Delete(fake.ServiceClient(), "af8a20b0-117d-4fc3-ae53-aa3968a4f870")
+	th.AssertNoErr(t, delete.Err)
+}
+
+func TestListV2Policy(t *testing.T) {
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/backuppolicy", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ListOutput)
+	})
+
+	actual, err := policies.List(fake.ServiceClient(), policies.ListOpts{})
+	if err != nil {
+		t.Errorf("Failed to extract clusters: %v", err)
+	}
+
+	expected := ListPolicies
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestAssociateV2Policy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/backuppolicyresources", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		th.TestJSONRequest(t, r, `
+{
+    "backup_policy_id":"915d1fd8-63cb-4054-a2b0-2778210e3a75",
+    "resources":[{
+        "resource_id":"0f187b65-8d0e-4fc0-9096-3b55d330531e",
+        "resource_type":"volume"
+        }]
+}
+`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, AssociateOutput)
+	})
+	AssoOpts := policies.AssociateOpts{PolicyID: "915d1fd8-63cb-4054-a2b0-2778210e3a75", Resources: []policies.AssociateResource{{ResourceID: "0f187b65-8d0e-4fc0-9096-3b55d330531e", ResourceType: "volume"}}}
+	associate, err := policies.Associate(fake.ServiceClient(), AssoOpts).ExtractResource()
+	th.AssertNoErr(t, err)
+	expected := Associate
+	th.AssertDeepEquals(t, expected, associate)
+}
+
+func TestDisassociateV2Policy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/backuppolicyresources/915d1fd8-63cb-4054-a2b0-2778210e3a75/deleted_resources", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		th.TestJSONRequest(t, r, `
+{
+    "resources": [
+        {
+            "resource_id": "0f187b65-8d0e-4fc0-9096-3b55d330531e"
+        }
+    ]
+}
+`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, DisssociateOutput)
+	})
+	options := policies.DisassociateOpts{Resources: []policies.DisassociateResource{{ResourceID: "0f187b65-8d0e-4fc0-9096-3b55d330531e"}}}
+	associate, err := policies.Disassociate(fake.ServiceClient(), "915d1fd8-63cb-4054-a2b0-2778210e3a75", options).ExtractResource()
+	th.AssertNoErr(t, err)
+	expected := Disassociate
+	th.AssertDeepEquals(t, expected, associate)
+}

--- a/openstack/vbs/v2/policies/urls.go
+++ b/openstack/vbs/v2/policies/urls.go
@@ -1,0 +1,24 @@
+package policies
+
+import "github.com/huaweicloud/golangsdk"
+
+const (
+	backupRootPath     = "backuppolicy"
+	policyResourcePath = "backuppolicyresources"
+)
+
+func commonURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(backupRootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL(backupRootPath, policyID)
+}
+
+func associateURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(policyResourcePath)
+}
+
+func disassociateURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL(policyResourcePath, policyID, "deleted_resources")
+}

--- a/openstack/vbs/v2/shares/doc.go
+++ b/openstack/vbs/v2/shares/doc.go
@@ -1,0 +1,46 @@
+/*
+Package shares enables management and retrieval of Shares
+VBS service.
+
+Example to List Shares
+
+	listOpts := shares.ListOpts{}
+	allShares, err := shares.List(vbsClient, listOpts)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, share := range allShares {
+		fmt.Printf("%+v\n", share)
+	}
+
+Example to Get a Share
+
+   getshare,err:=shares.Get(vbsClient, "6149e448-dcac-4691-96d9-041e09ef617f").ExtractShare()
+   if err != nil {
+         panic(err)
+		}
+
+   fmt.Println(getshare)
+
+Example to Create a Share
+
+	createOpts := shares.CreateOpts{BackupID:"87566ed6-72cb-4053-aa6e-6f6216b3d507",
+									ToProjectIDs:[]string{"91d687759aed45d28b5f6084bc2fa8ad"}}
+
+	share, err := shares.Create(vbsClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Share
+
+	shareID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+
+	deleteopts := shares.DeleteOpts{IsBackupID:false}
+	err := shares.Delete(vbsclient,shareID,deleteopts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package shares

--- a/openstack/vbs/v2/shares/requests.go
+++ b/openstack/vbs/v2/shares/requests.go
@@ -1,0 +1,180 @@
+package shares
+
+import (
+	"reflect"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// SortDir is a type for specifying in which direction to sort a list of Shares.
+type SortDir string
+
+var (
+	// SortAsc is used to sort a list of Shares in ascending order.
+	SortAsc SortDir = "asc"
+	// SortDesc is used to sort a list of Shares in descending order.
+	SortDesc SortDir = "desc"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the share attributes you want to see returned.
+type ListOpts struct {
+	ID               string
+	SnapshotID       string
+	ShareToMe        bool    `q:"share_to_me"`
+	Name             string  `q:"name"`
+	Status           string  `q:"status"`
+	BackupID         string  `q:"backup_id"`
+	FromProjectID    string  `q:"from_project_id"`
+	ToProjectID      string  `q:"to_project_id"`
+	AvailabilityZone string  `q:"availability_zone"`
+	SortDir          SortDir `q:"sort_dir"`
+	Limit            int     `q:"limit"`
+	Offset           int     `q:"offset"`
+	VolumeID         string  `q:"volume_id"`
+}
+
+// List returns collection of
+// share. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+// Default policy settings return only those share that are owned by the
+// tenant who submits the request, unless an admin user submits the request.
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Share, error) {
+	q, err := golangsdk.BuildQueryString(&opts)
+	if err != nil {
+		return nil, err
+	}
+	u := listURL(c) + q.String()
+	pages, err := pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
+		return SharePage{pagination.LinkedPageBase{PageResult: r}}
+	}).AllPages()
+
+	allShares, err := ExtractShareList(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	return FilterShares(allShares, opts)
+}
+
+func FilterShares(shares []Share, opts ListOpts) ([]Share, error) {
+
+	var refinedShares []Share
+	var matched bool
+	m := map[string]FilterStruct{}
+
+	if opts.ID != "" {
+		m["ID"] = FilterStruct{Value: opts.ID}
+	}
+	if opts.SnapshotID != "" {
+		m["SnapshotID"] = FilterStruct{Value: opts.SnapshotID, Driller: []string{"Backup"}}
+	}
+
+	if len(m) > 0 && len(shares) > 0 {
+		for _, share := range shares {
+			matched = true
+
+			for key, value := range m {
+				if sVal := GetStructNestedField(&share, key, value.Driller); !(sVal == value.Value) {
+					matched = false
+				}
+			}
+			if matched {
+				refinedShares = append(refinedShares, share)
+			}
+		}
+
+	} else {
+		refinedShares = shares
+	}
+
+	return refinedShares, nil
+}
+
+type FilterStruct struct {
+	Value   string
+	Driller []string
+}
+
+func GetStructNestedField(v *Share, field string, structDriller []string) string {
+	r := reflect.ValueOf(v)
+	for _, drillField := range structDriller {
+		f := reflect.Indirect(r).FieldByName(drillField).Interface()
+		r = reflect.ValueOf(f)
+	}
+	f1 := reflect.Indirect(r).FieldByName(field)
+	return string(f1.String())
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToShareCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new share.
+type CreateOpts struct {
+	//ID of the backup to be shared
+	BackupID string `json:"backup_id" required:"true"`
+	//IDs of projects with which the backup is shared
+	ToProjectIDs []string `json:"to_project_ids" required:"true"`
+}
+
+// ToShareCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToShareCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "shared")
+}
+
+// Create will create a new Share based on the values in CreateOpts. To extract
+// the Share object from the response, call the Extract method on the
+// CreateResult.
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToShareCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, reqOpt)
+	return
+}
+
+// Get retrieves a particular share based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+//DeleteOptsBuilder is an interface which can be able to build the query string
+//of share deletion.
+type DeleteOptsBuilder interface {
+	ToShareDeleteQuery() (string, error)
+}
+
+type DeleteOpts struct {
+	//Whether the ID in the URL is a backup share ID or a backup ID
+	IsBackupID bool `q:"is_backup_id"`
+}
+
+func (opts DeleteOpts) ToShareDeleteQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+//Delete is a method by which can be able to delete one or all shares of a backup.
+func Delete(client *golangsdk.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := resourceURL(client, id)
+	if opts != nil {
+		q, err := opts.ToShareDeleteQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += q
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = client.Delete(url, reqOpt)
+	return
+}

--- a/openstack/vbs/v2/shares/results.go
+++ b/openstack/vbs/v2/shares/results.go
@@ -20,13 +20,13 @@ type Share struct {
 	//ID of the project that shares the backup
 	FromProjectID string `json:"from_project_id"`
 	//Creation time of the backup share
-	CreatedAt time.Time `json:"created_at"`
+	CreatedAt time.Time `json:"-"`
 	//Update time of the backup share
-	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedAt time.Time `json:"-"`
 	//Whether the backup has been deleted
 	Deleted string `json:"deleted"`
 	//Deletion time
-	DeletedAt time.Time `json:"deleted_at"`
+	DeletedAt time.Time `json:"-"`
 }
 
 type Backup struct {

--- a/openstack/vbs/v2/shares/results.go
+++ b/openstack/vbs/v2/shares/results.go
@@ -1,0 +1,190 @@
+package shares
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type Share struct {
+	//Details about the source backup
+	Backup Backup `json:"backup"`
+	//Backup ID
+	BackupID string `json:"backup_id"`
+	//Backup share ID
+	ID string `json:"id"`
+	//ID of the project with which the backup is shared
+	ToProjectID string `json:"to_project_id"`
+	//ID of the project that shares the backup
+	FromProjectID string `json:"from_project_id"`
+	//Creation time of the backup share
+	CreatedAt time.Time `json:"created_at"`
+	//Update time of the backup share
+	UpdatedAt time.Time `json:"updated_at"`
+	//Whether the backup has been deleted
+	Deleted string `json:"deleted"`
+	//Deletion time
+	DeletedAt time.Time `json:"deleted_at"`
+}
+
+type Backup struct {
+	//Backup ID
+	ID string `json:"id"`
+	//Backup name
+	Name string `json:"name"`
+	//Backup status
+	Status string `json:"status"`
+	//Backup description
+	Description string `json:"description"`
+	//AZ where the backup resides
+	AvailabilityZone string `json:"availability_zone"`
+	//Source volume ID of the backup
+	VolumeID string `json:"volume_id"`
+	//Cause of the backup failure
+	FailReason string `json:"fail_reason"`
+	//Backup size
+	Size int `json:"size"`
+	//Number of objects on OBS for the disk data
+	ObjectCount int `json:"object_count"`
+	//Container of the backup
+	Container string `json:"container"`
+	//Backup creation time
+	CreatedAt time.Time `json:"-"`
+	//Backup metadata
+	ServiceMetadata string `json:"service_metadata"`
+	//Time when the backup was updated
+	UpdatedAt time.Time `json:"-"`
+	//Current time
+	DataTimeStamp time.Time `json:"-"`
+	//Whether a dependent backup exists
+	DependentBackups bool `json:"has_dependent_backups"`
+	//ID of the snapshot associated with the backup
+	SnapshotID string `json:"snapshot_id"`
+	//Whether the backup is an incremental backup
+	IsIncremental bool `json:"is_incremental"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// SharePage is the page returned by a pager when traversing over a
+// collection of Shares.
+type SharePage struct {
+	pagination.LinkedPageBase
+}
+
+// Extract is a function that accepts a result and extracts shares.
+func (r commonResult) Extract() ([]Share, error) {
+	var s struct {
+		Share []Share `json:"shared"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Share, err
+}
+
+// ExtractShare is a function that accepts a result and extracts a share.
+func (r commonResult) ExtractShare() (*Share, error) {
+	var s struct {
+		Share *Share `json:"shared"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Share, err
+}
+
+// NextPageURL is invoked when a paginated collection of Shares has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r SharePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []golangsdk.Link `json:"shared_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return golangsdk.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a SharePage struct is empty.
+func (r SharePage) IsEmpty() (bool, error) {
+	is, err := ExtractShareList(r)
+	return len(is) == 0, err
+}
+
+// ExtractShareList accepts a Page struct, specifically a SharePage struct,
+// and extracts the elements into a slice of Shares struct. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractShareList(r pagination.Page) ([]Share, error) {
+	var s struct {
+		Shares []Share `json:"shared"`
+	}
+	err := (r.(SharePage)).ExtractInto(&s)
+	return s.Shares, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Share.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its ExtractShare
+// method to interpret it as a Share.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+// UnmarshalJSON overrides the default, to convert the JSON API response into our Backup struct
+func (r *Backup) UnmarshalJSON(b []byte) error {
+	type tmp Backup
+	var s struct {
+		tmp
+		CreatedAt     golangsdk.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt     golangsdk.JSONRFC3339MilliNoZ `json:"updated_at"`
+		DataTimeStamp golangsdk.JSONRFC3339MilliNoZ `json:"data_timestamp"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Backup(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+	r.DataTimeStamp = time.Time(s.DataTimeStamp)
+
+	return nil
+}
+
+// UnmarshalJSON overrides the default, to convert the JSON API response into our Share struct
+func (r *Share) UnmarshalJSON(b []byte) error {
+	type tmp Share
+	var s struct {
+		tmp
+		CreatedAt golangsdk.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt golangsdk.JSONRFC3339MilliNoZ `json:"updated_at"`
+		DeletedAt golangsdk.JSONRFC3339MilliNoZ `json:"deleted_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Share(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+	r.DeletedAt = time.Time(s.DeletedAt)
+
+	return nil
+}

--- a/openstack/vbs/v2/shares/testing/fixtures.go
+++ b/openstack/vbs/v2/shares/testing/fixtures.go
@@ -1,0 +1,110 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/huaweicloud/golangsdk/openstack/vbs/v2/common"
+	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/shares"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+)
+
+// listResponse represents the response body from a List request.
+var listResponse = `{
+    "shared": [
+        {
+        "backup_id": "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+        "to_project_id": "91d687759aed45d28b5f6084bc2fa8ad",
+        "from_project_id": "17fbda95add24720a4038ba4b1c705ed",
+        "backup": {
+            "status": "available",
+            "object_count": 0,
+            "container": "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+            "name": "c2c-test-buckup",
+            "availability_zone": "eu-de-01",
+            "snapshot_id": "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+            "volume_id": "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+            "id": "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+            "size": 10
+        },
+        "id": "ac0fb374-a288-4399-ac63-cc080a13a2ee"
+    }
+  ]
+}`
+
+// getResponse represents the response body from a Get request.
+var getResponse = `{
+    "shared": {
+        "backup_id": "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+        "to_project_id": "91d687759aed45d28b5f6084bc2fa8ad",
+        "from_project_id": "17fbda95add24720a4038ba4b1c705ed",
+        "backup": {
+            "status": "available",
+            "object_count": 0,
+            "container": "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+            "name": "c2c-test-buckup",
+            "availability_zone": "eu-de-01",
+            "snapshot_id": "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+            "volume_id": "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+            "id": "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+            "size": 10
+        },
+        "id": "ac0fb374-a288-4399-ac63-cc080a13a2ee"
+    }
+}`
+
+// HandleGetSuccessfully creates an HTTP handler at `/os-vendor-backup-sharing/ac0fb374-a288-4399-ac63-cc080a13a2ee`
+// on the test handler mux that responds with a `Get` response.
+func HandleGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-vendor-backup-sharing/ac0fb374-a288-4399-ac63-cc080a13a2ee", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, getResponse)
+	})
+}
+
+// CreateExpected represents the expected object from a Create request.
+var CreateExpected = []shares.Share{{
+	BackupID:      "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+	ToProjectID:   "91d687759aed45d28b5f6084bc2fa8ad",
+	FromProjectID: "17fbda95add24720a4038ba4b1c705ed",
+	ID:            "34c38ce7-f35c-44f2-a8d8-8d4ebab0cfbb",
+},
+}
+
+// CreateOutput represents the response body from a Create request.
+const CreateOutput = `
+{
+    "shared": [
+        {
+            "backup_id": "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+            "to_project_id": "91d687759aed45d28b5f6084bc2fa8ad",
+            "from_project_id": "17fbda95add24720a4038ba4b1c705ed",
+            "id": "34c38ce7-f35c-44f2-a8d8-8d4ebab0cfbb"
+        }
+    ]
+}`
+
+// HandleCreateSuccessfully creates an HTTP handler at `/os-vendor-backup-sharing` on the test handler mux
+// that responds with a `Create` response.
+func HandleCreateSuccessfully(t *testing.T, output string) {
+	th.Mux.HandleFunc("/os-vendor-backup-sharing", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, output)
+	})
+}
+
+// HandleDeleteSuccessfully creates an HTTP handler at `/os-vendor-backup-sharing/87566ed6-72cb-4053-aa6e-6f6216b3d507`
+// on the test handler mux that responds with a `Delete` response.
+func HandleDeleteSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-vendor-backup-sharing/87566ed6-72cb-4053-aa6e-6f6216b3d507", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/openstack/vbs/v2/shares/testing/requests_test.go
+++ b/openstack/vbs/v2/shares/testing/requests_test.go
@@ -1,0 +1,101 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/huaweicloud/golangsdk/openstack/vbs/v2/common"
+	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/shares"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+)
+
+func TestListShared(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/os-vendor-backup-sharing/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, listResponse)
+	})
+
+	actual, err := shares.List(fake.ServiceClient(), shares.ListOpts{})
+	if err != nil {
+		t.Errorf("Failed to extract shares: %v", err)
+	}
+
+	expected := []shares.Share{
+		{
+			BackupID:      "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+			ToProjectID:   "91d687759aed45d28b5f6084bc2fa8ad",
+			FromProjectID: "17fbda95add24720a4038ba4b1c705ed",
+			ID:            "ac0fb374-a288-4399-ac63-cc080a13a2ee",
+			Backup: shares.Backup{Status: "available",
+				ObjectCount:      0,
+				Container:        "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+				Name:             "c2c-test-buckup",
+				AvailabilityZone: "eu-de-01",
+				SnapshotID:       "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+				VolumeID:         "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+				ID:               "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+				Size:             10},
+		},
+	}
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestGetShared(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleGetSuccessfully(t)
+
+	s, err := shares.Get(fake.ServiceClient(), "ac0fb374-a288-4399-ac63-cc080a13a2ee").ExtractShare()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, s, &shares.Share{
+		BackupID:      "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+		ToProjectID:   "91d687759aed45d28b5f6084bc2fa8ad",
+		FromProjectID: "17fbda95add24720a4038ba4b1c705ed",
+		ID:            "ac0fb374-a288-4399-ac63-cc080a13a2ee",
+		Backup: shares.Backup{Status: "available",
+			ObjectCount:      0,
+			Container:        "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+			Name:             "c2c-test-buckup",
+			AvailabilityZone: "eu-de-01",
+			SnapshotID:       "a704c75f-f0d1-4efa-9fd6-7557fe1ee8d3",
+			VolumeID:         "5024a06e-6990-4f12-9dcc-8fe26b01a710",
+			ID:               "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+			Size:             10},
+	})
+}
+
+func TestCreateShared(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateSuccessfully(t, CreateOutput)
+	createOpts := shares.CreateOpts{
+		BackupID:     "87566ed6-72cb-4053-aa6e-6f6216b3d507",
+		ToProjectIDs: []string{"91d687759aed45d28b5f6084bc2fa8ad"}}
+	actual, err := shares.Create(fake.ServiceClient(), createOpts).Extract()
+
+	th.AssertNoErr(t, err)
+
+	expected := CreateExpected
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestDeleteShared(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleDeleteSuccessfully(t)
+
+	deleteOpts := shares.DeleteOpts{
+		IsBackupID: true,
+	}
+	result := shares.Delete(fake.ServiceClient(), "87566ed6-72cb-4053-aa6e-6f6216b3d507", deleteOpts)
+	th.AssertNoErr(t, result.Err)
+}

--- a/openstack/vbs/v2/shares/urls.go
+++ b/openstack/vbs/v2/shares/urls.go
@@ -1,0 +1,17 @@
+package shares
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "os-vendor-backup-sharing"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id)
+}
+
+func listURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, "detail")
+}

--- a/openstack/vbs/v2/tags/doc.go
+++ b/openstack/vbs/v2/tags/doc.go
@@ -1,0 +1,43 @@
+package tags
+
+/*
+Package tags enables management and retrieval of policy's tags
+VBS service.
+
+Example to Add tag a Policy
+
+	createopts := tags.CreateOpts{
+						Tag:tags.Tag{Key:"test",Value:"demo"}
+				 }
+
+	create,err := tags.Create(client,"ed8b9f73-4415-494d-a54e-5f3373bc353d",createopts).Extract()
+
+Example to Get tag of a Policy
+
+   get,err := tags.Get(client,"ed8b9f73-4415-494d-a54e-5f3373bc353d").Extract()
+	fmt.Println(get,err)
+
+Example to delete a tag of a Policy
+
+    delete := tags.Delete(client,"5b549fad-c4e5-4d7e-83b9-eea366f27017","ECS")
+	fmt.Println(delete)
+
+Example to ListResources policy details based on tags
+
+   queryOpts := tags.ListOpts{
+					Action:"filter",
+					NotAnyTags:[]tags.RespTags{{Key:"newKey",Values:[]string{"volumeSphere"}}}
+				}
+
+   query,err :=tags.ListResources(client,queryOpts).ExtractResources()
+   fmt.Println(query,err)
+
+Example to perform batch tag actions on a backup policy
+
+	actionopts := tags.BatchOpts{
+						Action:"update",
+						RespTags:[]tags.Tag{{Key:"k22",Value:"v22"}}
+				}
+
+    action := tags.BatchAction(client,"ed8b9f73-4415-494d-a54e-5f3373bc353d",actionopts)
+*/

--- a/openstack/vbs/v2/tags/requests.go
+++ b/openstack/vbs/v2/tags/requests.go
@@ -1,0 +1,151 @@
+package tags
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToTagCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create or add a new tag.
+type CreateOpts struct {
+	Tag Tag `json:"tag" required:"true"`
+}
+
+// Tag is a structure of key value pair, used for create ,
+// update and delete operations.
+type Tag struct {
+	//tag key
+	Key string `json:"key" required:"true"`
+	//tag value
+	Value string `json:"value" required:"true"`
+}
+
+// ToTagCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToTagCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+//Adds a tag to a backup policy based on the values in CreateOpts. To extract
+// the tag object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToTagCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{204}}
+	_, r.Err = client.Post(commonURL(client, policyID), b, nil, reqOpt)
+	return
+}
+
+//deletes a tag ,specified in the key for a backup policy.
+func Delete(c *golangsdk.ServiceClient, policyID string, key string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, policyID, key), nil)
+	return
+}
+
+// Get retrieves the tags of a specific backup policy.
+func Get(client *golangsdk.ServiceClient, policyID string) (r GetResult) {
+	_, r.Err = client.Get(commonURL(client, policyID), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// ListResources request.
+type ListOptsBuilder interface {
+	ToTagsListMap() (map[string]interface{}, error)
+}
+
+// ListOpts contains all the values needed to ListResources the policy details based on tags.
+type ListOpts struct {
+	//Number of queried records. This parameter is not displayed if action is set to count.
+	Limit string `json:"limit,omitempty"`
+	//Query index,this parameter is not displayed if action is set to count.
+	Offset string `json:"offset,omitempty"`
+	//Backup policies with these tags will be filtered.
+	// This list can have a maximum of 10 tags.
+	Tags []Tags `json:"tags,omitempty"`
+	//Backup policies with any tags in this list will be filtered.
+	AnyTags []Tags `json:"tags_any,omitempty"`
+	//Backup policies without these tags will be filtered.
+	NotTags []Tags `json:"not_tags,omitempty"`
+	//Backup policies without any of these tags will be filtered.
+	NotAnyTags []Tags `json:"not_tags_any,omitempty"`
+	//Operator. Possible values are filter and count.
+	Action string `json:"action" required:"true"`
+}
+type Tags struct {
+	//Tag key
+	Key string `json:"key" required:"true"`
+	//list of values
+	Values []string `json:"values" required:"true"`
+}
+
+// ToTagsListMap builds a ListResources request body from ListOpts.
+func (opts ListOpts) ToTagsListMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+//ListResources retrives a backup policy details using tags.To extract
+// the tag object from the response, call the ExtractResources method on the
+// QueryResults.
+func ListResources(client *golangsdk.ServiceClient, opts ListOptsBuilder) (r QueryResults) {
+	b, err := opts.ToTagsListMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(listURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// BatchOptsBuilder allows extensions to add additional parameters to the
+// BatchAction request.
+type BatchOptsBuilder interface {
+	ToTagsBatchMap() (map[string]interface{}, error)
+}
+
+// BatchOpts contains all the values needed to perform BatchAction on the policy tags.
+type BatchOpts struct {
+	//List of tags to perform batch operation
+	Tags []Tag `json:"tags,omitempty"`
+	//Operator , Possible values are:create, update,delete
+	Action ActionType `json:"action" required:"true"`
+}
+
+//ActionType specifies the type of batch operation action to be performed
+type ActionType string
+
+var (
+	// ActionCreate is used to set action operator to create
+	ActionCreate ActionType = "create"
+	// ActionDelete is used to set action operator to delete
+	ActionDelete ActionType = "delete"
+	// ActionUpdate is used to set action operator to update
+	ActionUpdate ActionType = "update"
+)
+
+// ToTagsBatchMap builds a BatchAction request body from BatchOpts.
+func (opts BatchOpts) ToTagsBatchMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+//BatchAction is used to create ,update or delete the tags of a specified backup policy.
+func BatchAction(client *golangsdk.ServiceClient, policyID string, opts BatchOptsBuilder) (r ActionResults) {
+	b, err := opts.ToTagsBatchMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, policyID), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/openstack/vbs/v2/tags/results.go
+++ b/openstack/vbs/v2/tags/results.go
@@ -1,0 +1,62 @@
+package tags
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type RespTags struct {
+	//contains list of tags, i.e.key value pair
+	Tags []Tag `json:"tags"`
+}
+
+type Resources struct {
+	//List of resources i.e. policies
+	Resource []Resource `json:"resources"`
+	//Total number of resources
+	TotalCount int `json:"total_count"`
+}
+
+type Resource struct {
+	//Resource name
+	ResourceName string `json:"resource_name"`
+	//Resource ID
+	ResourceID string `json:"resource_id"`
+	//List of tags
+	Tags []Tag `json:"tags"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+type DeleteResult struct {
+	commonResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+type QueryResults struct {
+	commonResult
+}
+
+type ActionResults struct {
+	commonResult
+}
+
+func (r commonResult) Extract() (*RespTags, error) {
+	var response RespTags
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+func (r QueryResults) ExtractResources() (*Resources, error) {
+	var response Resources
+	err := r.ExtractInto(&response)
+	return &response, err
+}

--- a/openstack/vbs/v2/tags/testing/fixtures.go
+++ b/openstack/vbs/v2/tags/testing/fixtures.go
@@ -1,0 +1,58 @@
+package testing
+
+import (
+	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/tags"
+)
+
+const TagList = `
+{
+  "total_count":1,
+  "resources":[
+    {
+      "resource_name": "name",
+      "resource_id": "0781095c-b8ab-4ce5-99f3-4c5f6ff75319",
+      "resource_detail": null,
+      "tags": [{
+          "key":"key",
+          "value":"value"
+       }]
+    }
+  ]
+}`
+
+var AddTag = `
+{
+    "tag":{
+        "key":"0f187b65-8d0e-4fc0-9096-3b55d330531e",
+        "value":"volume"
+    }
+}`
+
+var getTags = `{
+  "tags": [
+    {
+      "key": "RUNNING",
+      "value":"0781095c-b8ab-4ce5-99f3-4c5f6ff75319"
+    },
+    {
+      "key": "WAITING",
+      "values":"2016-12-03T06:24:34.467"
+    }
+  ]
+}`
+
+var batchAction = `{
+    "action":"update",
+    "tags":[{
+        "key":"0f187b65-8d0e-4fc0-9096-3b55d330531e",
+        "value":"volume"
+        },{
+        "key":"0f187b65-8d0e-4fc0-9096-3b55d330531d",
+        "value":"volume"
+    }]
+}`
+
+var ExpectedTags = &tags.Resources{
+	TotalCount: 1,
+	Resource:   []tags.Resource{{ResourceName: "name", ResourceID: "0781095c-b8ab-4ce5-99f3-4c5f6ff75319", Tags: []tags.Tag{{Key: "key", Value: "value"}}}},
+}

--- a/openstack/vbs/v2/tags/testing/requests_test.go
+++ b/openstack/vbs/v2/tags/testing/requests_test.go
@@ -1,0 +1,103 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/huaweicloud/golangsdk/openstack/vbs/v2/common"
+	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/tags"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+)
+
+func TestCreateV2Tag(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/backuppolicy/ed8b9f73-4415-494d-a54e-5f3373bc353d/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestJSONRequest(t, r, AddTag)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	options := tags.CreateOpts{Tag: tags.Tag{Key: "0f187b65-8d0e-4fc0-9096-3b55d330531e", Value: "volume"}}
+	s := tags.Create(fake.ServiceClient(), "ed8b9f73-4415-494d-a54e-5f3373bc353d", options)
+	th.AssertNoErr(t, s.Err)
+}
+
+func TestDeleteV2Tag(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/backuppolicy/ed8b9f73-4415-494d-a54e-5f3373bc353d/tags/K1", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	delete := tags.Delete(fake.ServiceClient(), "ed8b9f73-4415-494d-a54e-5f3373bc353d", "K1")
+	th.AssertNoErr(t, delete.Err)
+}
+
+func TestGetV2Tag(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/backuppolicy/ed8b9f73-4415-494d-a54e-5f3373bc353d/tags", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, getTags)
+	})
+
+	s, err := tags.Get(fake.ServiceClient(), "ed8b9f73-4415-494d-a54e-5f3373bc353d").Extract()
+
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, s, &tags.RespTags{Tags: []tags.Tag{{Key: "RUNNING", Value: "0781095c-b8ab-4ce5-99f3-4c5f6ff75319"}, {Key: "WAITING", Value: ""}}})
+}
+
+func TestBatchActionsV2Tag(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/backuppolicy/ed8b9f73-4415-494d-a54e-5f3373bc353d/tags/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestJSONRequest(t, r, batchAction)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	options := tags.BatchOpts{Action: tags.ActionUpdate, Tags: []tags.Tag{{Key: "0f187b65-8d0e-4fc0-9096-3b55d330531e", Value: "volume"}, {Key: "0f187b65-8d0e-4fc0-9096-3b55d330531d", Value: "volume"}}}
+	s := tags.BatchAction(fake.ServiceClient(), "ed8b9f73-4415-494d-a54e-5f3373bc353d", options)
+	th.AssertNoErr(t, s.Err)
+}
+
+func TestQueryV2Tags(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/backuppolicy/resource_instances/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		th.TestJSONRequest(t, r, `
+{ 
+  "tags":
+      [
+        {
+           "key": "Tag001",
+           "values":["Value001","Value002"]
+         }
+       ],
+  "action":"filter"
+}
+`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, TagList)
+	})
+	queryOpts := tags.ListOpts{Action: "filter", Tags: []tags.Tags{{Key: "Tag001", Values: []string{"Value001", "Value002"}}}}
+	actual, err := tags.ListResources(fake.ServiceClient(), queryOpts).ExtractResources()
+	th.AssertNoErr(t, err)
+	expected := ExpectedTags
+	th.AssertDeepEquals(t, expected, actual)
+}

--- a/openstack/vbs/v2/tags/urls.go
+++ b/openstack/vbs/v2/tags/urls.go
@@ -1,0 +1,21 @@
+package tags
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "backuppolicy"
+
+func commonURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL(rootPath, policyID, "tags")
+}
+
+func deleteURL(c *golangsdk.ServiceClient, policyID string, key string) string {
+	return c.ServiceURL(rootPath, policyID, "tags", key)
+}
+
+func listURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, "resource_instances", "action")
+}
+
+func actionURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL(rootPath, policyID, "tags", "action")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PR adds the capability to manage vbs service actions using golangsdk

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: As the vbs clientType is different for different cloud providers for locating endpoint, hence there are 3 client methods for different cloud providers.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

