### PR TITLE
bug-fix: cannot find global service endpoint

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -358,9 +358,6 @@ func v3AKSKAuth(client *golangsdk.ProviderClient, endpoint string, options golan
 		}
 
 		client.EndpointLocator = func(opts golangsdk.EndpointOpts) (string, error) {
-			if opts.Region == "" {
-				opts.Region = options.Region
-			}
 			return V3EndpointURL(&tokens3.ServiceCatalog{
 				Entries: entries,
 			}, opts)


### PR DESCRIPTION
**What this PR does / why we need it**:
the client cannot find the endpoint when the service is a global service which doesnot register any region.
when opts.Region is empty, we should keep it as it was. do not set the default value when it is empty.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

