### PR TITLE
Fix csbs policy Operation Def field type conversion

### DIFF
--- a/openstack/csbs/v1/policies/results.go
+++ b/openstack/csbs/v1/policies/results.go
@@ -100,9 +100,31 @@ func (r *OperationDefinitionResp) UnmarshalJSON(b []byte) error {
 		RetentionDurationDays string `json:"retention_duration_days"`
 		Permanent             string `json:"permanent"`
 	}
+
 	err := json.Unmarshal(b, &s)
+
 	if err != nil {
-		return err
+		switch err.(type) {
+		case *json.UnmarshalTypeError: //check if type error occurred (handles if no type conversion is required for cloud like Huawei)
+
+			var s struct {
+				tmp
+				MaxBackups            int  `json:"max_backups"`
+				RetentionDurationDays int  `json:"retention_duration_days"`
+				Permanent             bool `json:"permanent"`
+			}
+			err := json.Unmarshal(b, &s)
+			if err != nil {
+				return err
+			}
+			*r = OperationDefinitionResp(s.tmp)
+			r.MaxBackups = s.MaxBackups
+			r.RetentionDurationDays = s.RetentionDurationDays
+			r.Permanent = s.Permanent
+			return nil
+		default:
+			return err
+		}
 	}
 
 	*r = OperationDefinitionResp(s.tmp)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: In HW Cloud, CSBS Get and List Policy Operation Def resp doesn't require type conversion, contrary to other clouds, so this PR handles that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

