### PR TITLE
Fix CCE Cluster Endpoints field

### DIFF
--- a/openstack/cce/v3/clusters/testing/fixtures.go
+++ b/openstack/cce/v3/clusters/testing/fixtures.go
@@ -36,6 +36,38 @@ const Output = `
     }
 }`
 
+const OutputOTC = `
+{
+    "kind": "Cluster",
+    "apiVersion": "v3",
+    "metadata": {
+        "name": "test-cluster",
+        "uid": "daa97872-59d7-11e8-a787-0255ac101f54"
+    },
+    "spec": {
+        "type": "VirtualMachine",
+        "flavor": "cce.s1.small",
+        "version": "v1.7.3-r10",
+        "hostNetwork": {
+            "vpc": "3305eb40-2707-4940-921c-9f335f84a2ca",
+            "subnet": "00e41db7-e56b-4946-bf91-27bb9effd664"
+        },
+        "containerNetwork": {
+            "mode": "overlay_l2"
+        },
+        "billingMode": 0
+    },
+    "status": {
+        "phase": "Available",
+        "endpoints": {
+			"internal": "https://192.168.0.68:5443",
+            "external": "https://10.34.56.78:5443",
+			"external_otc": "https://4d1ecb2c-229a-11e8-9c75-0255ac100ceb.container.eu-de.otc.t-systems.com"
+		}
+                
+    }
+}`
+
 var Expected = &clusters.Clusters{
 	Kind:       "Cluster",
 	ApiVersion: "v3",
@@ -60,6 +92,35 @@ var Expected = &clusters.Clusters{
 		Phase: "Available",
 		Endpoints: []clusters.Endpoints{
 			{Url: "https://192.168.0.68:5443", Type: "Internal"},
+		},
+	},
+}
+
+var ExpectedOTC = &clusters.Clusters{
+	Kind:       "Cluster",
+	ApiVersion: "v3",
+	Metadata: clusters.MetaData{
+		Name: "test-cluster",
+		Id:   "daa97872-59d7-11e8-a787-0255ac101f54",
+	},
+	Spec: clusters.Spec{
+		Type:    "VirtualMachine",
+		Flavor:  "cce.s1.small",
+		Version: "v1.7.3-r10",
+		HostNetwork: clusters.HostNetworkSpec{
+			VpcId:    "3305eb40-2707-4940-921c-9f335f84a2ca",
+			SubnetId: "00e41db7-e56b-4946-bf91-27bb9effd664",
+		},
+		ContainerNetwork: clusters.ContainerNetworkSpec{
+			Mode: "overlay_l2",
+		},
+		BillingMode: 0,
+	},
+	Status: clusters.Status{
+		Phase: "Available",
+		Endpoints: []clusters.Endpoints{
+			{Internal: "https://192.168.0.68:5443", External: "https://10.34.56.78:5443",
+				ExternalOTC: "https://4d1ecb2c-229a-11e8-9c75-0255ac100ceb.container.eu-de.otc.t-systems.com"},
 		},
 	},
 }
@@ -101,6 +162,42 @@ const ListOutput = `
 }
 `
 
+const ListOutputOTC = `
+{
+ "items": [
+        {
+            "kind": "Cluster",
+            "apiVersion": "v3",
+            "metadata": {
+                "name": "test123",
+                "uid": "daa97872-59d7-11e8-a787-0255ac101f54"
+            },
+            "spec": {
+                "type": "VirtualMachine",
+                "flavor": "cce.s1.small",
+                "version": "v1.7.3-r10",
+                "hostNetwork": {
+                    "vpc": "3305eb40-2707-4940-921c-9f335f84a2ca",
+                    "subnet": "00e41db7-e56b-4946-bf91-27bb9effd664"
+                },
+                "containerNetwork": {
+                    "mode": "overlay_l2"
+                },
+                "billingMode": 0
+            },
+            "status": {
+                "phase": "Available",
+                "endpoints": {
+					"internal": "https://192.168.0.68:5443",
+            		"external": "https://10.34.56.78:5443",
+					"external_otc": "https://4d1ecb2c-229a-11e8-9c75-0255ac100ceb.container.eu-de.otc.t-systems.com"
+				}
+            }
+        }
+    ]
+}
+`
+
 var ListExpected = []clusters.Clusters{
 	{
 		Kind:       "Cluster",
@@ -114,5 +211,27 @@ var ListExpected = []clusters.Clusters{
 			Version:          "v1.7.3-r10",
 		},
 		Status: clusters.Status{Phase: "Available", Endpoints: []clusters.Endpoints{{Url: "https://192.168.0.68:5443", Type: "Internal"}}},
+	},
+}
+
+var ListExpectedOTC = []clusters.Clusters{
+	{
+		Kind:       "Cluster",
+		ApiVersion: "v3",
+		Metadata:   clusters.MetaData{Name: "test123", Id: "daa97872-59d7-11e8-a787-0255ac101f54"},
+		Spec: clusters.Spec{Type: "VirtualMachine",
+			Flavor:           "cce.s1.small",
+			HostNetwork:      clusters.HostNetworkSpec{VpcId: "3305eb40-2707-4940-921c-9f335f84a2ca", SubnetId: "00e41db7-e56b-4946-bf91-27bb9effd664"},
+			ContainerNetwork: clusters.ContainerNetworkSpec{Mode: "overlay_l2"},
+			BillingMode:      0,
+			Version:          "v1.7.3-r10",
+		},
+		Status: clusters.Status{
+			Phase: "Available",
+			Endpoints: []clusters.Endpoints{
+				{Internal: "https://192.168.0.68:5443", External: "https://10.34.56.78:5443",
+					ExternalOTC: "https://4d1ecb2c-229a-11e8-9c75-0255ac100ceb.container.eu-de.otc.t-systems.com"},
+			},
+		},
 	},
 }

--- a/openstack/cce/v3/clusters/testing/requests_test.go
+++ b/openstack/cce/v3/clusters/testing/requests_test.go
@@ -29,6 +29,25 @@ func TestGetV3Cluster(t *testing.T) {
 
 }
 
+func TestGetV3ClusterOTC(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/api/v3/projects/c59fd21fd2a94963b822d8985b884673/clusters/daa97872-59d7-11e8-a787-0255ac101f54", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, OutputOTC)
+	})
+
+	actual, err := clusters.Get(fake.ServiceClient(), "daa97872-59d7-11e8-a787-0255ac101f54").Extract()
+	th.AssertNoErr(t, err)
+	expected := ExpectedOTC
+	th.AssertDeepEquals(t, expected, actual)
+
+}
+
 func TestListV3Cluster(t *testing.T) {
 
 	th.SetupHTTP()
@@ -55,6 +74,34 @@ func TestListV3Cluster(t *testing.T) {
 
 	th.AssertDeepEquals(t, expected, actual)
 }
+
+func TestListV3ClusterOTC(t *testing.T) {
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/api/v3/projects/c59fd21fd2a94963b822d8985b884673/clusters", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, ListOutputOTC)
+	})
+
+	//count := 0
+
+	actual, err := clusters.List(fake.ServiceClient(), clusters.ListOpts{})
+	if err != nil {
+		t.Errorf("Failed to extract clusters: %v", err)
+	}
+
+	expected := ListExpectedOTC
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
 func TestCreateV3Cluster(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: In OTC Cloud, CCE Get and List cluster API response has `endpoints` field as a single object and in HW Cloud, the `endpoints` field is list of objects, so this PR handles that.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: The OTC CCE terraform is dependent on this PR.

**Release note**: 
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

