### PR TITLE
add header for agency when authorized by aksk

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -497,6 +497,18 @@ func getDomainID(name string, client *golangsdk.ServiceClient) (string, error) {
 	}
 }
 
+func HeaderForAdminToken(c *golangsdk.ServiceClient) (map[string]string, error) {
+	if c.AKSKAuthOptions.AccessKey != "" {
+		i, err := getDomainID(c.AKSKAuthOptions.Domain, c)
+		if err != nil {
+			return nil, err
+		}
+
+		return map[string]string{"X-Domain-Id": i}, nil
+	}
+	return nil, nil
+}
+
 // NewIdentityV2 creates a ServiceClient that may be used to interact with the
 // v2 identity service.
 func NewIdentityV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {

--- a/openstack/identity/v3/agency/requests.go
+++ b/openstack/identity/v3/agency/requests.go
@@ -1,6 +1,9 @@
 package agency
 
-import "github.com/huaweicloud/golangsdk"
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack"
+)
 
 type CreateOpts struct {
 	Name            string `json:"name" required:"true"`
@@ -23,7 +26,15 @@ func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult)
 		r.Err = err
 		return
 	}
-	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+
+	reqOpt := &golangsdk.RequestOpts{}
+	err = addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, reqOpt)
 	return
 }
 
@@ -46,51 +57,121 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 		r.Err = err
 		return
 	}
+
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	err = addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
 	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, reqOpt)
 	return
 }
 
 func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	reqOpt := &golangsdk.RequestOpts{}
+	err := addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, reqOpt)
 	return
 }
 
 func Delete(c *golangsdk.ServiceClient, id string) (r ErrResult) {
-	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	reqOpt := &golangsdk.RequestOpts{}
+	err := addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Delete(resourceURL(c, id), reqOpt)
 	return
 }
 
 func AttachRoleByProject(c *golangsdk.ServiceClient, agencyID, projectID, roleID string) (r ErrResult) {
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{204}}
+	err := addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
 	_, r.Err = c.Put(roleURL(c, "projects", projectID, agencyID, roleID), nil, nil, reqOpt)
 	return
 }
 
 func AttachRoleByDomain(c *golangsdk.ServiceClient, agencyID, domainID, roleID string) (r ErrResult) {
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{204}}
+	err := addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
 	_, r.Err = c.Put(roleURL(c, "domains", domainID, agencyID, roleID), nil, nil, reqOpt)
 	return
 }
 
 func DetachRoleByProject(c *golangsdk.ServiceClient, agencyID, projectID, roleID string) (r ErrResult) {
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{204}}
+	err := addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
 	_, r.Err = c.Delete(roleURL(c, "projects", projectID, agencyID, roleID), reqOpt)
 	return
 }
 
 func DetachRoleByDomain(c *golangsdk.ServiceClient, agencyID, domainID, roleID string) (r ErrResult) {
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{204}}
+	err := addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
 	_, r.Err = c.Delete(roleURL(c, "domains", domainID, agencyID, roleID), reqOpt)
 	return
 }
 
 func ListRolesAttachedOnProject(c *golangsdk.ServiceClient, agencyID, projectID string) (r ListRolesResult) {
-	_, r.Err = c.Get(listRolesURL(c, "projects", projectID, agencyID), &r.Body, nil)
+	reqOpt := &golangsdk.RequestOpts{}
+	err := addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Get(listRolesURL(c, "projects", projectID, agencyID), &r.Body, reqOpt)
 	return
 }
 
 func ListRolesAttachedOnDomain(c *golangsdk.ServiceClient, agencyID, domainID string) (r ListRolesResult) {
-	_, r.Err = c.Get(listRolesURL(c, "domains", domainID, agencyID), &r.Body, nil)
+	reqOpt := &golangsdk.RequestOpts{}
+	err := addHeaderWhenAuthByAKSK(c, reqOpt)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Get(listRolesURL(c, "domains", domainID, agencyID), &r.Body, reqOpt)
 	return
+}
+
+func addHeaderWhenAuthByAKSK(c *golangsdk.ServiceClient, opt *golangsdk.RequestOpts) error {
+	h, err := openstack.HeaderForAdminToken(c)
+	if err != nil {
+		return err
+	}
+	if h != nil {
+		opt.MoreHeaders = h
+	}
+	return nil
 }

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -2,6 +2,7 @@ package roles
 
 import (
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack"
 	"github.com/huaweicloud/golangsdk/pagination"
 )
 
@@ -37,9 +38,19 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 		url += query
 	}
 
-	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+	h, err := openstack.HeaderForAdminToken(client)
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+
+	pager := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return RolePage{pagination.LinkedPageBase{PageResult: r}}
 	})
+
+	if h != nil {
+		pager.Headers = h
+	}
+	return pager
 }
 
 // Get retrieves details on a single role, by ID.


### PR DESCRIPTION
The api of Agency and Role need the header of "X-Auth-Token" that is a token with role of "Security Administrator". If using AKSK to authorize and invoke them, it needs another header of "X-Domain-Id". 