### PR TITLE
fix set an empty value for header of X-Project-Id

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -308,7 +308,11 @@ func v3AKSKAuth(client *golangsdk.ProviderClient, endpoint string, options golan
 		v3Client.Endpoint = endpoint
 	}
 
+	defer func() {
+		v3Client.AKSKAuthOptions.ProjectId = options.ProjectId
+	}()
 	v3Client.AKSKAuthOptions = options
+	v3Client.AKSKAuthOptions.ProjectId = ""
 
 	if options.ProjectId == "" && options.ProjectName != "" {
 		id, err := getProjectID(v3Client, options.ProjectName)

--- a/provider_client.go
+++ b/provider_client.go
@@ -234,7 +234,9 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			AccessKey: client.AKSKAuthOptions.AccessKey,
 			SecretKey: client.AKSKAuthOptions.SecretKey,
 		})
-		req.Header.Set("X-Project-Id", client.AKSKAuthOptions.ProjectId)
+		if client.AKSKAuthOptions.ProjectId != "" {
+			req.Header.Set("X-Project-Id", client.AKSKAuthOptions.ProjectId)
+		}
 	}
 
 	// Issue the request.


### PR DESCRIPTION
if set an empty value for header of X-Project-Id, it will failed for request.