### PR TITLE
Refactor auth by agency

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -249,18 +249,16 @@ func v3auth(client *golangsdk.ProviderClient, endpoint string, opts tokens3.Auth
 }
 
 func v3authWithAgency(client *golangsdk.ProviderClient, endpoint string, opts *golangsdk.AuthOptions, eo golangsdk.EndpointOpts) error {
-	token := opts.TokenID
-	if token == "" {
+	if opts.TokenID == "" {
 		err := v3auth(client, endpoint, opts, eo)
 		if err != nil {
 			return err
 		}
-		token = client.TokenID
-		client.TokenID = ""
+	} else {
+		client.TokenID = opts.TokenID
 	}
 
 	opts1 := golangsdk.AgencyAuthOptions{
-		TokenID:          token,
 		AgencyName:       opts.AgencyName,
 		AgencyDomainName: opts.AgencyDomainName,
 		DelegatedProject: opts.DelegatedProject,


### PR DESCRIPTION
No need to add header of "X-Auth-Token" actively, because the provlider client will add it automaticly at [here](https://github.com/huaweicloud/golangsdk/blob/master/provider_client.go#L102-L106) if client.TokenID is not empty. 