### PR TITLE
Remove omitempty attribute in *InstanceNumber of UpdateOpts

### DIFF
--- a/openstack/autoscaling/v1/groups/requests.go
+++ b/openstack/autoscaling/v1/groups/requests.go
@@ -113,9 +113,9 @@ type UpdateOptsBuilder interface {
 //UpdateOpts is a struct which represents the parameters of update function
 type UpdateOpts struct {
 	Name                      string              `json:"scaling_group_name,omitempty"`
-	DesireInstanceNumber      int                 `json:"desire_instance_number,omitempty"`
-	MinInstanceNumber         int                 `json:"min_instance_number,omitempty"`
-	MaxInstanceNumber         int                 `json:"max_instance_number,omitempty"`
+	DesireInstanceNumber      int                 `json:"desire_instance_number"`
+	MinInstanceNumber         int                 `json:"min_instance_number"`
+	MaxInstanceNumber         int                 `json:"max_instance_number"`
 	CoolDownTime              int                 `json:"cool_down_time,omitempty"`
 	LBListenerID              string              `json:"lb_listener_id,omitempty"`
 	LBaaSListeners            []LBaaSListenerOpts `json:"lbaas_listeners,omitempty"`


### PR DESCRIPTION
It has no effect when updating *InstanceNumber to zero
with omitempty attribute, we'd better remove them.

Signed-off-by: ShiChangkuo <shichangkuo90@gmail.com>
