### PR TITLE
modify the type of SSL in InstanceResponse to int

### DIFF
--- a/openstack/dds/v3/instances/results.go
+++ b/openstack/dds/v3/instances/results.go
@@ -83,7 +83,7 @@ type InstanceResponse struct {
 	Created           string         `json:"created"`
 	Updated           string         `json:"updated"`
 	DbUserName        string         `json:"db_user_name"`
-	Ssl               string         `json:"ssl"`
+	Ssl               int            `json:"ssl"`
 	VpcId             string         `json:"vpc_id"`
 	SubnetId          string         `json:"subnet_id"`
 	SecurityGroupId   string         `json:"security_group_id"`


### PR DESCRIPTION
According to the [API document](https://support.huaweicloud.com/en-us/api-dds/dds_api_0023.html), the type of SSL in InstanceResponse has changed to integer, so we should synchronize it.




