### PR TITLE
add http2_enable parameter in lb listeners

### DIFF
--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -106,11 +106,17 @@ type CreateOpts struct {
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`
 
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
 
 	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref,omitempty"`
 
 	// Specifies the security policy used by the listener.
 	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`
@@ -165,11 +171,17 @@ type UpdateOpts struct {
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`
 
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
 
 	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref,omitempty"`
 
 	// Specifies the security policy used by the listener.
 	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`

--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
@@ -44,8 +44,14 @@ type Listener struct {
 	// Default is -1, meaning no limit.
 	ConnLimit int `json:"connection_limit"`
 
+	// whether to use HTTP2.
+	Http2Enable bool `json:"http2_enable"`
+
 	// The list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref"`
 
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref"`


### PR DESCRIPTION
add http2_enable parameter in lb listeners according to [API documention](https://support.huaweicloud.com/en-us/api-elb/elb_zq_jt_0001.html)