### PR TITLE
fix waf api using old server props

### DIFF
--- a/openstack/waf/v1/domains/requests.go
+++ b/openstack/waf/v1/domains/requests.go
@@ -32,9 +32,9 @@ type CreateOpts struct {
 
 type ServerOpts struct {
 	//Protocol type of the client
-	FrontProtocol string `json:"front_protocol" required:"true"`
+	ClientProtocol string `json:"client_protocol" required:"true"`
 	//Protocol used by WAF to forward client requests to the server
-	BackProtocol string `json:"back_protocol" required:"true"`
+	ServerProtocol string `json:"server_protocol" required:"true"`
 	//IP address or domain name of the web server that the client accesses.
 	Address string `json:"address" required:"true"`
 	//Port number used by the web server

--- a/openstack/waf/v1/domains/results.go
+++ b/openstack/waf/v1/domains/results.go
@@ -39,9 +39,9 @@ type Domain struct {
 
 type Server struct {
 	//Protocol type of the client
-	FrontProtocol string `json:"front_protocol" required:"true"`
+	ClientProtocol string `json:"client_protocol" required:"true"`
 	//Protocol used by WAF to forward client requests to the server
-	BackProtocol string `json:"back_protocol" required:"true"`
+	ServerProtocol string `json:"server_protocol" required:"true"`
 	//IP address or domain name of the web server that the client accesses.
 	Address string `json:"address" required:"true"`
 	//Port number used by the web server


### PR DESCRIPTION
**What this PR does / why we need it**:
The server props of waf domain were changed from front_protocol and back_protocol
to client_protocol and server_protocol without changing api version, this PR also does that in this lib.
https://docs.otc.t-systems.com/en-us/api/waf/waf_02_0013.html

**Special notes for your reviewer**:
The terraform provider is broken because of this.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

