### PR TITLE
Add retry functionality to ProviderClient.Request

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -29,6 +29,8 @@ const (
 
 	// provider represents the suffix of endpoint url
 	provider = "myhuaweicloud.com"
+
+	defaultRetries = 10
 )
 
 /*
@@ -45,7 +47,7 @@ A basic example of using this would be:
 	provider, err := openstack.NewClient(ao.IdentityEndpoint)
 	client, err := openstack.NewIdentityV3(provider, golangsdk.EndpointOpts{})
 */
-func NewClient(endpoint string) (*golangsdk.ProviderClient, error) {
+func NewClient(endpoint string, maxRetries ...int) (*golangsdk.ProviderClient, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
@@ -67,6 +69,11 @@ func NewClient(endpoint string) (*golangsdk.ProviderClient, error) {
 	p := new(golangsdk.ProviderClient)
 	p.IdentityBase = base
 	p.IdentityEndpoint = endpoint
+	if len(maxRetries) == 0 {
+		p.MaxRetries = defaultRetries
+	} else {
+		p.MaxRetries = maxRetries[0]
+	}
 	p.UseTokenLock()
 
 	return p, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Required for implementing terraform-providers/terraform-provider-opentelekomcloud#512

**Special notes for your reviewer**:
Implementation of retry for API call requires configuring client additionally. Now `maxRetries` set to non-default value only when using `NewClient` method

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

