### PR TITLE
set private_key to optional in lb certificates

### DIFF
--- a/openstack/networking/v2/extensions/lbaas_v2/certificates/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/certificates/requests.go
@@ -58,7 +58,7 @@ type CreateOpts struct {
 	Description string `json:"description,omitempty"`
 	Type        string `json:"type,omitempty"`
 	Domain      string `json:"domain,omitempty"`
-	PrivateKey  string `json:"private_key" required:"true"`
+	PrivateKey  string `json:"private_key,omitempty"`
 	Certificate string `json:"certificate" required:"true"`
 }
 


### PR DESCRIPTION
according to the API document, `private_key` is optional for lb certificates