### PR TITLE
fix 403 response for css snapshot enable API

### DIFF
--- a/openstack/css/v1/snapshots/requests.go
+++ b/openstack/css/v1/snapshots/requests.go
@@ -48,7 +48,8 @@ func PolicyGet(client *golangsdk.ServiceClient, clusterId string) (r PolicyResul
 
 // Enable will enable the Snapshot function with the provided ID.
 func Enable(client *golangsdk.ServiceClient, clusterId string) (r ErrorResult) {
-	_, r.Err = client.Post(enableURL(client, clusterId), nil, nil, &golangsdk.RequestOpts{
+	body := make(map[string]interface{})
+	_, r.Err = client.Post(enableURL(client, clusterId), body, nil, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
 	})


### PR DESCRIPTION
using "{}" instead of nil as request body, otherwise, we will get 403 response code from the enable/auto_setting API.