### PR TITLE
change okCodes of smn Delete func

### DIFF
--- a/openstack/smn/v2/subscriptions/requests.go
+++ b/openstack/smn/v2/subscriptions/requests.go
@@ -46,7 +46,10 @@ func Create(client *golangsdk.ServiceClient, ops CreateOpsBuilder, topicUrn stri
 
 //delete a subscription via subscription urn
 func Delete(client *golangsdk.ServiceClient, subscriptionUrn string) (r DeleteResult) {
-	_, r.Err = client.Delete(deleteURL(client, subscriptionUrn), &RequestOpts)
+	_, r.Err = client.Delete(deleteURL(client, subscriptionUrn), &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 
@@ -58,12 +61,16 @@ func Delete(client *golangsdk.ServiceClient, subscriptionUrn string) (r DeleteRe
 
 //list all the subscriptions
 func List(client *golangsdk.ServiceClient) (r ListResult) {
-	_, r.Err = client.Get(listURL(client), &r.Body, &RequestOpts)
+	_, r.Err = client.Get(listURL(client), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 
 //list all the subscriptions
 func ListFromTopic(client *golangsdk.ServiceClient, subscriptionUrn string) (r ListResult) {
-	_, r.Err = client.Get(listFromTopicURL(client, subscriptionUrn), &r.Body, &RequestOpts)
+	_, r.Err = client.Get(listFromTopicURL(client, subscriptionUrn), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }

--- a/openstack/smn/v2/topics/requests.go
+++ b/openstack/smn/v2/topics/requests.go
@@ -77,18 +77,25 @@ func Update(client *golangsdk.ServiceClient, ops UpdateOpsBuilder, id string) (r
 
 //delete a topic via id
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
-	_, r.Err = client.Delete(deleteURL(client, id), &RequestOpts)
+	_, r.Err = client.Delete(deleteURL(client, id), &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 
 //get a topic with detailed information by id
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = client.Get(getURL(client, id), &r.Body, &RequestOpts)
+	_, r.Err = client.Get(getURL(client, id), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 
 //list all the topics
 func List(client *golangsdk.ServiceClient) (r ListResult) {
-	_, r.Err = client.Get(listURL(client), &r.Body, &RequestOpts)
+	_, r.Err = client.Get(listURL(client), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }


### PR DESCRIPTION
The old okCodes of Delete func is wrong, update to [200]
rewrite Get func, List func and List func to avoid unexpect err

In the old code, Get func, Delete func and List func were using the same &RequestOpts. The okCodes of the &RequestOpts will been written by the first called func. So an err will occur if the okCodes of the following called func is different.