### PR TITLE
support rename of rds instance

### DIFF
--- a/openstack/rds/v3/instances/requests.go
+++ b/openstack/rds/v3/instances/requests.go
@@ -172,6 +172,33 @@ func Restart(client *golangsdk.ServiceClient, opts RestartRdsInstanceBuilder, in
 	return
 }
 
+type RenameRdsInstanceOpts struct {
+	Name string `json:"name" required:"true"`
+}
+
+type RenameRdsInstanceBuilder interface {
+	ToRenameRdsInstanceMap() (map[string]interface{}, error)
+}
+
+func (opts RenameRdsInstanceOpts) ToRenameRdsInstanceMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(&opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Rename(client *golangsdk.ServiceClient, opts RenameRdsInstanceBuilder, instanceId string) error {
+	b, err := opts.ToRenameRdsInstanceMap()
+	if err != nil {
+		return err
+	}
+	_, err = client.Put(renameURL(client, instanceId), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return err
+}
+
 type ListRdsInstanceOpts struct {
 	Id            string `q:"id"`
 	Name          string `q:"name"`

--- a/openstack/rds/v3/instances/requests.go
+++ b/openstack/rds/v3/instances/requests.go
@@ -166,7 +166,7 @@ func Restart(client *golangsdk.ServiceClient, opts RestartRdsInstanceBuilder, in
 		return
 	}
 	fmt.Println("restart Rds instance body = ", b)
-	_, r.Err = client.Post(restartURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return
@@ -188,15 +188,16 @@ func (opts RenameRdsInstanceOpts) ToRenameRdsInstanceMap() (map[string]interface
 	return b, nil
 }
 
-func Rename(client *golangsdk.ServiceClient, opts RenameRdsInstanceBuilder, instanceId string) error {
+func Rename(client *golangsdk.ServiceClient, opts RenameRdsInstanceBuilder, instanceId string) (r golangsdk.Result) {
 	b, err := opts.ToRenameRdsInstanceMap()
 	if err != nil {
-		return err
+		r.Err = err
+		return
 	}
-	_, err = client.Put(renameURL(client, instanceId), b, nil, &golangsdk.RequestOpts{
-		OkCodes: []int{200},
+	_, r.Err = client.Put(updateURL(client, instanceId, "name"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
 	})
-	return err
+	return
 }
 
 type ListRdsInstanceOpts struct {
@@ -269,7 +270,7 @@ func SingleToHa(client *golangsdk.ServiceClient, opts SingleToRdsHaBuilder, inst
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(singletohaURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 
@@ -302,7 +303,7 @@ func Resize(client *golangsdk.ServiceClient, opts ResizeFlavorBuilder, instanceI
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(resizeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 
@@ -335,7 +336,7 @@ func EnlargeVolume(client *golangsdk.ServiceClient, opts EnlargeVolumeBuilder, i
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(enlargeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 
@@ -363,7 +364,7 @@ func (opts DbErrorlogOpts) DbErrorlogQuery() (string, error) {
 }
 
 func ListErrorLog(client *golangsdk.ServiceClient, opts DbErrorlogBuilder, instanceID string) pagination.Pager {
-	url := listerrorlogURL(client, instanceID)
+	url := updateURL(client, instanceID, "errorlog")
 	if opts != nil {
 		query, err := opts.DbErrorlogQuery()
 
@@ -403,7 +404,7 @@ func (opts DbSlowLogOpts) ToDbSlowLogListQuery() (string, error) {
 }
 
 func ListSlowLog(client *golangsdk.ServiceClient, opts DbSlowLogBuilder, instanceID string) pagination.Pager {
-	url := listslowlogURL(client, instanceID)
+	url := updateURL(client, instanceID, "slowlog")
 	if opts != nil {
 		query, err := opts.ToDbSlowLogListQuery()
 

--- a/openstack/rds/v3/instances/urls.go
+++ b/openstack/rds/v3/instances/urls.go
@@ -22,6 +22,10 @@ func singletohaURL(c *golangsdk.ServiceClient, instancesId string) string {
 	return c.ServiceURL("instances", instancesId, "action")
 }
 
+func renameURL(c *golangsdk.ServiceClient, instancesId string) string {
+	return c.ServiceURL("instances", instancesId, "name")
+}
+
 func resizeURL(c *golangsdk.ServiceClient, instancesId string) string {
 	return c.ServiceURL("instances", instancesId, "action")
 }

--- a/openstack/rds/v3/instances/urls.go
+++ b/openstack/rds/v3/instances/urls.go
@@ -14,30 +14,6 @@ func listURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("instances")
 }
 
-func restartURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func singletohaURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func renameURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "name")
-}
-
-func resizeURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func enlargeURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func listerrorlogURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "errorlog")
-}
-
-func listslowlogURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "slowlog")
+func restartURL(c *golangsdk.ServiceClient, instancesId string, updata string) string {
+	return c.ServiceURL("instances", instancesId, updata)
 }

--- a/openstack/rds/v3/instances/urls.go
+++ b/openstack/rds/v3/instances/urls.go
@@ -14,6 +14,6 @@ func listURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("instances")
 }
 
-func restartURL(c *golangsdk.ServiceClient, instancesId string, updata string) string {
+func updateURL(c *golangsdk.ServiceClient, instancesId string, updata string) string {
 	return c.ServiceURL("instances", instancesId, updata)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Huaweicloud API support rename instance, we need to support rename function in Huaweicloud sdk.

**Which issue this PR fixes**:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
```
1. Add name struct, opts and some function(toMap, Rename) to instances request.
2. Add rename urls to instances urls
```

