### PR TITLE
[Feature] Server group supports members updation

### DIFF
--- a/openstack/compute/v2/extensions/servergroups/requests.go
+++ b/openstack/compute/v2/extensions/servergroups/requests.go
@@ -57,3 +57,30 @@ func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
+
+type MemberOptsBuilder interface {
+	ToServerGroupUpdateMemberMap(string) (map[string]interface{}, error)
+}
+
+type MemberOpts struct {
+	InstanceUUid string `json:"instance_uuid" required:"true"`
+}
+
+func (opts MemberOpts) ToServerGroupUpdateMemberMap(optsType string) (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, optsType)
+}
+
+// UpdateMembers is used to add and delete members from Server Group.
+// (params)optsType: The opts type is title of block in request body.
+//                   Add options is add_memebr and remove options is remove_member.
+func UpdateMember(client *golangsdk.ServiceClient, opts MemberOptsBuilder, optsType, id string) (r MemberResult) {
+	b, err := opts.ToServerGroupUpdateMemberMap(optsType)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}

--- a/openstack/compute/v2/extensions/servergroups/results.go
+++ b/openstack/compute/v2/extensions/servergroups/results.go
@@ -93,3 +93,9 @@ type GetResult struct {
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
+
+// MemberResult is the response from a Member update operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type MemberResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
@@ -158,3 +158,37 @@ func HandleDeleteSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	})
 }
+
+func HandleAddMemberSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/cloudservers/os-server-groups/616fb98f-46ca-475e-917e-2563e5a8cd19/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+{
+    "add_member": {
+        "instance_uuid": "d194d539-07b0-446e-b52c-e639e618e49d"
+    }
+}
+`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func HandleRemoveMemberSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/cloudservers/os-server-groups/616fb98f-46ca-475e-917e-2563e5a8cd19/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+{
+    "remove_member": {
+        "instance_uuid": "d194d539-07b0-446e-b52c-e639e618e49d"
+    }
+}
+`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/servergroups/testing/requests_test.go
@@ -58,3 +58,25 @@ func TestDelete(t *testing.T) {
 	err := servergroups.Delete(client.ServiceClient(), "616fb98f-46ca-475e-917e-2563e5a8cd19").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestAddMember(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAddMemberSuccessfully(t)
+
+	err := servergroups.UpdateMember(client.ServiceClient(), servergroups.MemberOpts{
+		InstanceUUid: "d194d539-07b0-446e-b52c-e639e618e49d",
+	}, "add_member", "616fb98f-46ca-475e-917e-2563e5a8cd19").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestRemoveMember(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleRemoveMemberSuccessfully(t)
+
+	err := servergroups.UpdateMember(client.ServiceClient(), servergroups.MemberOpts{
+		InstanceUUid: "d194d539-07b0-446e-b52c-e639e618e49d",
+	}, "remove_member", "616fb98f-46ca-475e-917e-2563e5a8cd19").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/servergroups/urls.go
+++ b/openstack/compute/v2/extensions/servergroups/urls.go
@@ -20,6 +20,10 @@ func getURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id)
 }
 
+func actionURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("cloudservers", resourcePath, id, "action")
+}
+
 func deleteURL(c *golangsdk.ServiceClient, id string) string {
 	return getURL(c, id)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
According to server group API, server group supports members add and remove operation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. sdk supports members add and remove operation.
2. add unit test function.
```

## Unit tests

```
go test -v
=== RUN   TestAddMember
--- PASS: TestAddMember (0.00s)
=== RUN   TestRemoveMember
--- PASS: TestRemoveMember (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/testing  0.011s
```