### PR TITLE
support eni network in cce cluster

### DIFF
--- a/openstack/cce/v3/clusters/results.go
+++ b/openstack/cce/v3/clusters/results.go
@@ -56,6 +56,8 @@ type Spec struct {
 	HostNetwork HostNetworkSpec `json:"hostNetwork" required:"true"`
 	//Container network parameters
 	ContainerNetwork ContainerNetworkSpec `json:"containerNetwork" required:"true"`
+	//ENI network parameters
+	EniNetwork EniNetworkSpec `json:"eniNetwork,omitempty"`
 	//Authentication parameters
 	Authentication AuthenticationSpec `json:"authentication,omitempty"`
 	// Charging mode of the cluster, which is 0 (on demand)
@@ -87,6 +89,13 @@ type ContainerNetworkSpec struct {
 	Mode string `json:"mode" required:"true"`
 	//Container network segment: 172.16.0.0/16 ~ 172.31.0.0/16. If there is a network segment conflict, it will be automatically reselected.
 	Cidr string `json:"cidr,omitempty"`
+}
+
+type EniNetworkSpec struct {
+	//Eni network subnet id
+	SubnetId string `json:"eniSubnetId" required:"true"`
+	//Eni network cidr
+	Cidr string `json:"eniSubnetCIDR" required:"true"`
 }
 
 //Authentication parameters

--- a/openstack/cce/v3/clusters/testing/fixtures.go
+++ b/openstack/cce/v3/clusters/testing/fixtures.go
@@ -23,6 +23,10 @@ const Output = `
         "containerNetwork": {
             "mode": "overlay_l2"
         },
+        "eniNetwork": {
+			"eniSubnetCIDR": "192.168.2.0/24",
+			"eniSubnetId": "fb8f0799-94a7-4ea3-99ca-1d9c3c8d1526"
+		},
         "billingMode": 0
     },
     "status": {
@@ -85,6 +89,10 @@ var Expected = &clusters.Clusters{
 		},
 		ContainerNetwork: clusters.ContainerNetworkSpec{
 			Mode: "overlay_l2",
+		},
+		EniNetwork: clusters.EniNetworkSpec{
+			SubnetId: "fb8f0799-94a7-4ea3-99ca-1d9c3c8d1526",
+			Cidr:     "192.168.2.0/24",
 		},
 		BillingMode: 0,
 	},

--- a/openstack/cce/v3/clusters/testing/requests_test.go
+++ b/openstack/cce/v3/clusters/testing/requests_test.go
@@ -129,7 +129,11 @@ func TestCreateV3Cluster(t *testing.T) {
         },
         "containerNetwork": {
             "mode": "overlay_l2"
-        },
+		},
+		"eniNetwork": {
+			"eniSubnetCIDR": "192.168.2.0/24",
+			"eniSubnetId": "fb8f0799-94a7-4ea3-99ca-1d9c3c8d1526"
+		},
         "authentication": {
             "mode": "rbac",
 			"authenticatingProxy": {}
@@ -153,6 +157,10 @@ func TestCreateV3Cluster(t *testing.T) {
 				VpcId:    "3305eb40-2707-4940-921c-9f335f84a2ca",
 				SubnetId: "00e41db7-e56b-4946-bf91-27bb9effd664"},
 			ContainerNetwork: clusters.ContainerNetworkSpec{Mode: "overlay_l2"},
+			EniNetwork: clusters.EniNetworkSpec{
+				SubnetId: "fb8f0799-94a7-4ea3-99ca-1d9c3c8d1526",
+				Cidr:     "192.168.2.0/24",
+			},
 			Authentication: clusters.AuthenticationSpec{
 				Mode:                "rbac",
 				AuthenticatingProxy: make(map[string]string)},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support eni network in cce cluster
eni network is needed when creating a cce turbo cluster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

