### PR TITLE
[Feature] Agency duration supports updation

### DIFF
--- a/openstack/identity/v3/agency/requests.go
+++ b/openstack/identity/v3/agency/requests.go
@@ -9,6 +9,7 @@ type CreateOpts struct {
 	DomainID        string `json:"domain_id" required:"true"`
 	DelegatedDomain string `json:"trust_domain_name" required:"true"`
 	Description     string `json:"description,omitempty"`
+	Duration        string `json:"duration,omitempty"`
 }
 
 type CreateOptsBuilder interface {
@@ -33,6 +34,7 @@ func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult)
 type UpdateOpts struct {
 	DelegatedDomain string `json:"trust_domain_name,omitempty"`
 	Description     string `json:"description,omitempty"`
+	Duration        string `json:"duration,omitempty"`
 }
 
 type UpdateOptsBuilder interface {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Identity agency supports duration setting and updating, valid value is "ONEDAY", "FOREVER" and null (null will set duration with 'FOREVER'). Only agency createOpts and updateOpts need contains duration parameter, the resource can set and update in create and update function.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. new param 'Duration' in create and update opts.
```

