### PR TITLE
change type of ExtendParam to map, support FixedIp and HwPassthrough in cce node

### DIFF
--- a/openstack/cce/v3/nodes/results.go
+++ b/openstack/cce/v3/nodes/results.go
@@ -66,7 +66,7 @@ type Spec struct {
 	// The node nic spec
 	NodeNicSpec NodeNicSpec `json:"nodeNicSpec,omitempty"`
 	// Extended parameter
-	ExtendParam ExtendParam `json:"extendParam,omitempty"`
+	ExtendParam map[string]interface{} `json:"extendParam,omitempty"`
 	// UUID of an ECS group
 	EcsGroupID string `json:"ecsGroupId,omitempty"`
 	// Tag of a VM, key value pair format
@@ -87,6 +87,8 @@ type NodeNicSpec struct {
 type PrimaryNic struct {
 	// The Subnet ID of the primary Nic
 	SubnetId string `json:"subnetId,omitempty"`
+	// Fixed ips of the primary Nic
+	FixedIps []string `json:"fixedIps,omitempty"`
 }
 
 // TaintSpec to created nodes to configure anti-affinity
@@ -134,27 +136,10 @@ type VolumeSpec struct {
 	Size int `json:"size" required:"true"`
 	// Disk type
 	VolumeType string `json:"volumetype" required:"true"`
+	//hw:passthrough
+	HwPassthrough bool `json:"hw:passthrough,omitempty"`
 	// Disk extension parameter
 	ExtendParam map[string]interface{} `json:"extendParam,omitempty"`
-}
-
-type ExtendParam struct {
-	// Node charging mode, 0 is on-demand charging.
-	ChargingMode int `json:"chargingMode,omitempty"`
-	// Classification of cloud server specifications.
-	EcsPerformanceType string `json:"ecs:performancetype,omitempty"`
-	// Order ID, mandatory when the node payment type is the automatic payment package period type.
-	OrderID string `json:"orderID,omitempty"`
-	// The Product ID.
-	ProductID string `json:"productID,omitempty"`
-	// The Public Key.
-	PublicKey string `json:"publicKey,omitempty"`
-	// The maximum number of instances a node is allowed to create.
-	MaxPods int `json:"maxPods,omitempty"`
-	// Script required before the installation.
-	PreInstall string `json:"alpha.cce/preInstall,omitempty"`
-	// Script required after the installation.
-	PostInstall string `json:"alpha.cce/postInstall,omitempty"`
 }
 
 type PublicIPSpec struct {

--- a/openstack/cce/v3/nodes/testing/fixtures.go
+++ b/openstack/cce/v3/nodes/testing/fixtures.go
@@ -42,8 +42,7 @@ var Expected = &nodes.Nodes{
 		Login: nodes.LoginSpec{
 			SshKey: "test-keypair",
 		},
-		ExtendParam: nodes.ExtendParam{},
-		PublicIP:    nodes.PublicIPSpec{Eip: nodes.EipSpec{Bandwidth: nodes.BandwidthOpts{}, IpType: ""}},
+		PublicIP: nodes.PublicIPSpec{Eip: nodes.EipSpec{Bandwidth: nodes.BandwidthOpts{}, IpType: ""}},
 		RootVolume: nodes.VolumeSpec{
 			VolumeType: "SATA",
 			Size:       40,

--- a/openstack/cce/v3/nodes/testing/requests_test.go
+++ b/openstack/cce/v3/nodes/testing/requests_test.go
@@ -138,8 +138,6 @@ func TestCreateV3Node(t *testing.T) {
 	  "spec": {
 	    "az": "cn-east-2a",
 	    "count": 1,
-        "extendParam": {
-        },
 	    "dataVolumes": [
 	      {
 	        "size": 100,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

change type of of ExtendParam to map, deprecate the previous struct, so the ExtendParam can accept any key/value input
add two new param FixedIp and HwPassthrough

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

