### PR TITLE
VPC subnet supports IPv6 enable

### DIFF
--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -139,6 +139,7 @@ type CreateOpts struct {
 	CIDR             string         `json:"cidr" required:"true"`
 	DnsList          []string       `json:"dnsList,omitempty"`
 	GatewayIP        string         `json:"gateway_ip" required:"true"`
+	EnableIPv6       *bool          `json:"ipv6_enable,omitempty"`
 	EnableDHCP       bool           `json:"dhcp_enable" no_default:"y"`
 	PRIMARY_DNS      string         `json:"primary_dns,omitempty"`
 	SECONDARY_DNS    string         `json:"secondary_dns,omitempty"`
@@ -188,6 +189,7 @@ type UpdateOptsBuilder interface {
 // UpdateOpts contains the values used when updating a subnets.
 type UpdateOpts struct {
 	Name          string         `json:"name,omitempty"`
+	EnableIPv6    *bool          `json:"ipv6_enable,omitempty"`
 	EnableDHCP    bool           `json:"dhcp_enable"`
 	PRIMARY_DNS   string         `json:"primary_dns,omitempty"`
 	SECONDARY_DNS string         `json:"secondary_dns,omitempty"`

--- a/openstack/networking/v1/subnets/results.go
+++ b/openstack/networking/v1/subnets/results.go
@@ -25,6 +25,15 @@ type Subnet struct {
 	//Specifies the gateway of the subnet.
 	GatewayIP string `json:"gateway_ip"`
 
+	//Specifies whether the IPv6 function is enabled for the subnet.
+	EnableIPv6 bool `json:"ipv6_enable"`
+
+	//Specifies the IPv6 subnet CIDR block.
+	IPv6CIDR string `json:"cidr_v6"`
+
+	//Specifies the IPv6 subnet gateway.
+	IPv6Gateway string `json:"gateway_ip_v6"`
+
 	//Specifies whether the DHCP function is enabled for the subnet.
 	EnableDHCP bool `json:"dhcp_enable"`
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
According to HUAWEI CLOUD API, VPC subent can enable IPv6 by ipv6_enable parameter.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. request supports IPv6 enable.
2. response supports IPv6 enable, CIDR and gateway.
```

