### PR TITLE
CCE cluster supports deleting associated items

### DIFF
--- a/openstack/cce/v3/clusters/requests.go
+++ b/openstack/cce/v3/clusters/requests.go
@@ -191,6 +191,44 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 	return
 }
 
+type DeleteOpts struct {
+	ErrorStatus string `q:"errorStatus"`
+	DeleteEfs   string `q:"delete_efs"`
+	DeleteENI   string `q:"delete_eni"`
+	DeleteEvs   string `q:"delete_evs"`
+	DeleteNet   string `q:"delete_net"`
+	DeleteObs   string `q:"delete_obs"`
+	DeleteSfs   string `q:"delete_sfs"`
+}
+
+type DeleteOptsBuilder interface {
+	ToDeleteQuery() (string, error)
+}
+
+func (opts DeleteOpts) ToDeleteQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// DeleteWithOpts will permanently delete a particular cluster based on its unique ID,
+// and can delete associated resources based on DeleteOpts.
+func DeleteWithOpts(c *golangsdk.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := resourceURL(c, id)
+	if opts != nil {
+		var query string
+		query, r.Err = opts.ToDeleteQuery()
+		if r.Err != nil {
+			return
+		}
+		url += query
+	}
+	_, r.Err = c.Delete(url, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+	})
+	return
+}
+
 // Delete will permanently delete a particular cluster based on its unique ID.
 func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, id), &golangsdk.RequestOpts{

--- a/openstack/cce/v3/clusters/testing/requests_test.go
+++ b/openstack/cce/v3/clusters/testing/requests_test.go
@@ -208,3 +208,24 @@ func TestDeleteV3Cluster(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 }
+
+func TestDeleteWithOptsV3Cluster(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/api/v3/projects/c59fd21fd2a94963b822d8985b884673/clusters/daa97872-59d7-11e8-a787-0255ac101f54", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusOK)
+	})
+	options := clusters.DeleteOpts{
+		DeleteEfs: "true",
+		DeleteENI: "true",
+		DeleteEvs: "true",
+		DeleteNet: "true",
+		DeleteObs: "true",
+		DeleteSfs: "true",
+	}
+	err := clusters.DeleteWithOpts(fake.ServiceClient(), "daa97872-59d7-11e8-a787-0255ac101f54", options).ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CCE cluster API supports deleting associated items, such as efs, eni, evs, net, obs and sfs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. new enum value to select the associated resource to be deleted.
```

## Acceptance Steps Performed
```
go test -v -run TestDeleteWithOptsV3Cluster
=== RUN   TestDeleteWithOptsV3Cluster
--- PASS: TestDeleteWithOptsV3Cluster (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/testing      0.019s
```