### PR TITLE
[cce node pool]change param Type in UpdateSpec to omitempty

### DIFF
--- a/openstack/cce/v3/nodepools/requests.go
+++ b/openstack/cce/v3/nodepools/requests.go
@@ -181,7 +181,7 @@ type UpdateMetaData struct {
 // UpdateSpec describes Node pools update specification
 type UpdateSpec struct {
 	// Node type. Currently, only VM nodes are supported.
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 	// Node template
 	NodeTemplate nodes.Spec `json:"nodeTemplate"`
 	// Initial number of expected nodes


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

change param Type in UpdateSpec to omitempty
The parameter Type was optional but not omitempty, this makes the update request body contain `"type": ""` and cause error

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

