### PR TITLE
change ExtendParam to map[string]interface in cce cluster

### DIFF
--- a/openstack/cce/v3/clusters/results.go
+++ b/openstack/cce/v3/clusters/results.go
@@ -63,7 +63,7 @@ type Spec struct {
 	// Charging mode of the cluster, which is 0 (on demand)
 	BillingMode int `json:"billingMode,omitempty"`
 	//Extended parameter for a cluster
-	ExtendParam map[string]string `json:"extendParam,omitempty"`
+	ExtendParam map[string]interface{} `json:"extendParam,omitempty"`
 	//Advanced configuration of master node
 	Masters []MasterSpec `json:"masters,omitempty"`
 	//Range of kubernetes clusterIp


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
change change ExtendParam to map[string]interface, then we can support parameters of prePaid.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

