### PR TITLE
RDS supports querying task status through job id

### DIFF
--- a/openstack/rds/v3/instances/requests.go
+++ b/openstack/rds/v3/instances/requests.go
@@ -423,3 +423,35 @@ func ListSlowLog(client *golangsdk.ServiceClient, opts DbSlowLogBuilder, instanc
 	pageRdsList.Headers = rdsheader
 	return pageRdsList
 }
+
+type RDSJobOpts struct {
+	JobID string `q:"id"`
+}
+
+type RDSJobBuilder interface {
+	ToRDSJobQuery() (string, error)
+}
+
+func (opts RDSJobOpts) ToRDSJobQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+func GetRDSJob(client *golangsdk.ServiceClient, opts RDSJobBuilder) (r RDSJobResult) {
+	url := jobURL(client)
+	if opts != nil {
+		query, err := opts.ToRDSJobQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+	})
+	return
+}

--- a/openstack/rds/v3/instances/results.go
+++ b/openstack/rds/v3/instances/results.go
@@ -262,3 +262,27 @@ func ExtractSlowLog(r pagination.Page) (SlowLogResp, error) {
 	err := (r.(SlowLogPage)).ExtractInto(&s)
 	return s, err
 }
+
+type RDSJobResult struct {
+	commonResult
+}
+
+type ListJob struct {
+	Job Job `json:"job"`
+}
+
+type Job struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Created    string `json:"created"`
+	Ended      string `json:"ended"`
+	Process    string `json:"process"`
+	FailReason string `json:"fail_reason"`
+}
+
+func (r RDSJobResult) Extract() (ListJob, error) {
+	var s ListJob
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/openstack/rds/v3/instances/urls.go
+++ b/openstack/rds/v3/instances/urls.go
@@ -17,3 +17,7 @@ func listURL(c *golangsdk.ServiceClient) string {
 func updateURL(c *golangsdk.ServiceClient, instancesId string, updata string) string {
 	return c.ServiceURL("instances", instancesId, updata)
 }
+
+func jobURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("jobs")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Query job status check to ensure correctness of rds (single and read replica) resource status during update.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. new function to get rds job status.
```

