### PR TITLE
[dds instance]change type of KeepDays to *int and add param Period in BackupStrategy

### DIFF
--- a/openstack/dds/v3/instances/requests.go
+++ b/openstack/dds/v3/instances/requests.go
@@ -39,7 +39,8 @@ type Flavor struct {
 
 type BackupStrategy struct {
 	StartTime string `json:"start_time" required:"true"`
-	KeepDays  int    `json:"keep_days,omitempty"`
+	KeepDays  *int   `json:"keep_days,omitempty"`
+	Period    string `json:"period,omitempty"`
 }
 
 type CreateInstanceBuilder interface {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
change type of KeepDays to *int, so the value can be set to 0
add param Period, so the BackupStrategy struct can be used while updating backup_strategy through the backups/policy API 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

