### PR TITLE
[lbaas_v2/monitors] make expected_codes be optional for HTTP(S) types

### DIFF
--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
@@ -112,12 +112,11 @@ type CreateOpts struct {
 	URLPath string `json:"url_path,omitempty"`
 
 	// The HTTP method used for requests by the Monitor. If this attribute
-	// is not specified, it defaults to "GET". Required for HTTP(S) types.
+	// is not specified, it defaults to "GET".
 	HTTPMethod string `json:"http_method,omitempty"`
 
 	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
-	// a single status like "200", or a range like "200-202". Required for HTTP(S)
-	// types.
+	// a single status like "200", or a range like "200-202".
 	ExpectedCodes string `json:"expected_codes,omitempty"`
 
 	// TenantID is the UUID of the project who owns the Monitor.
@@ -141,21 +140,15 @@ type CreateOpts struct {
 
 // ToMonitorCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
+	if opts.Type == TypeHTTP || opts.Type == TypeHTTPS {
+		if opts.URLPath == "" {
+			return nil, fmt.Errorf("url_path must be provided for HTTP and HTTPS")
+		}
+	}
+
 	b, err := golangsdk.BuildRequestBody(opts, "healthmonitor")
 	if err != nil {
 		return nil, err
-	}
-
-	switch opts.Type {
-	case TypeHTTP, TypeHTTPS:
-		switch opts.URLPath {
-		case "":
-			return nil, fmt.Errorf("URLPath must be provided for HTTP and HTTPS")
-		}
-		switch opts.ExpectedCodes {
-		case "":
-			return nil, fmt.Errorf("ExpectedCodes must be provided for HTTP and HTTPS")
-		}
 	}
 
 	return b, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```
$ go test -v
=== RUN   TestListHealthmonitors
--- PASS: TestListHealthmonitors (0.00s)
=== RUN   TestListAllHealthmonitors
--- PASS: TestListAllHealthmonitors (0.00s)
=== RUN   TestCreateHealthmonitor
--- PASS: TestCreateHealthmonitor (0.00s)
=== RUN   TestRequiredCreateOpts
--- PASS: TestRequiredCreateOpts (0.00s)
=== RUN   TestGetHealthmonitor
--- PASS: TestGetHealthmonitor (0.00s)
=== RUN   TestDeleteHealthmonitor
--- PASS: TestDeleteHealthmonitor (0.00s)
=== RUN   TestUpdateHealthmonitor
--- PASS: TestUpdateHealthmonitor (0.00s)
=== RUN   TestDelayMustBeGreaterOrEqualThanTimeout
--- PASS: TestDelayMustBeGreaterOrEqualThanTimeout (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/monitors/testing   0.018s
```