### PR TITLE
Add ID to security group struct in ECS response

### DIFF
--- a/openstack/ecs/v1/cloudservers/results.go
+++ b/openstack/ecs/v1/cloudservers/results.go
@@ -72,6 +72,7 @@ type VolumeAttached struct {
 
 type SecurityGroups struct {
 	Name string `json:"name"`
+	ID   string `json:"id"`
 }
 
 // CloudServer is only used for method that requests details on a single server, by ID.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Security groups can have duplicate names. Therefore, ECS resources cannot find the corresponding security group when querying the bound security rule.
Now we need to change the rule form by name to by ID because ID is unique.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. add ID to security group struct in ECS response
```

