### PR TITLE
Update the versions type in spec struct

### DIFF
--- a/openstack/cce/v3/templates/results.go
+++ b/openstack/cce/v3/templates/results.go
@@ -1,6 +1,9 @@
 package templates
 
-import "github.com/huaweicloud/golangsdk"
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/cce/v3/addons"
+)
 
 type commonResult struct {
 	golangsdk.Result
@@ -25,16 +28,11 @@ type Metadata struct {
 }
 
 type Spec struct {
-	Type        string     `json:"type"`
-	Labels      []string   `json:"labels"`
-	LogoURL     string     `json:"logoURL"`
-	Description string     `json:"description"`
-	Versions    []Versions `json:"versions"`
-}
-
-type Versions struct {
-	Version string      `json:"version"`
-	Input   interface{} `json:"input"`
+	Type        string            `json:"type"`
+	Labels      []string          `json:"labels"`
+	LogoURL     string            `json:"logoURL"`
+	Description string            `json:"description"`
+	Versions    []addons.Versions `json:"versions"`
 }
 
 func (r ListResutlt) Extract() ([]Template, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update the type of version in spec struct from `[]Versions` to `addons.Versions` because of the struct content don't have 'stable', 'support version' and so on.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. update the versions parameter type in spec struct.
```

