### PR TITLE
Restore deleted openstack api

### DIFF
--- a/openstack/compute/v2/extensions/startstop/doc.go
+++ b/openstack/compute/v2/extensions/startstop/doc.go
@@ -1,0 +1,19 @@
+/*
+Package startstop provides functionality to start and stop servers that have
+been provisioned by the OpenStack Compute service.
+
+Example to Stop and Start a Server
+
+	serverID := "47b6b7b7-568d-40e4-868c-d5c41735532e"
+
+	err := startstop.Stop(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+	err := startstop.Start(computeClient, serverID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package startstop

--- a/openstack/compute/v2/extensions/startstop/requests.go
+++ b/openstack/compute/v2/extensions/startstop/requests.go
@@ -1,0 +1,19 @@
+package startstop
+
+import "github.com/huaweicloud/golangsdk"
+
+func actionURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "action")
+}
+
+// Start is the operation responsible for starting a Compute server.
+func Start(client *golangsdk.ServiceClient, id string) (r StartResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-start": nil}, nil, nil)
+	return
+}
+
+// Stop is the operation responsible for stopping a Compute server.
+func Stop(client *golangsdk.ServiceClient, id string) (r StopResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-stop": nil}, nil, nil)
+	return
+}

--- a/openstack/compute/v2/extensions/startstop/results.go
+++ b/openstack/compute/v2/extensions/startstop/results.go
@@ -1,0 +1,15 @@
+package startstop
+
+import "github.com/huaweicloud/golangsdk"
+
+// StartResult is the response from a Start operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type StartResult struct {
+	golangsdk.ErrResult
+}
+
+// StopResult is the response from Stop operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type StopResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/compute/v2/extensions/startstop/testing/doc.go
+++ b/openstack/compute/v2/extensions/startstop/testing/doc.go
@@ -1,0 +1,2 @@
+// startstop unit tests
+package testing

--- a/openstack/compute/v2/extensions/startstop/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/startstop/testing/fixtures.go
@@ -1,0 +1,27 @@
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func mockStartServerResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"os-start": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockStopServerResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"os-stop": null}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/startstop/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/startstop/testing/requests_test.go
@@ -1,0 +1,31 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/startstop"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const serverID = "{serverId}"
+
+func TestStart(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockStartServerResponse(t, serverID)
+
+	err := startstop.Start(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestStop(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockStopServerResponse(t, serverID)
+
+	err := startstop.Stop(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The openstack api of ecs instance power on/off was deleted by mistake.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. Restore deleted openstack api
```

