### PR TITLE
New autoscaling lifecycle hook sdk

### DIFF
--- a/openstack/autoscaling/v1/lifecyclehooks/requests.go
+++ b/openstack/autoscaling/v1/lifecyclehooks/requests.go
@@ -50,13 +50,13 @@ func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder, groupID str
 
 // Get is a method to obtains the hook detail of autoscaling service.
 func Get(client *golangsdk.ServiceClient, groupID, hookName string) (r GetResult) {
-	_, r.Err = client.Get(resourceURL(client, groupID, hookName), &r.Body, &golangsdk.RequestOpts{})
+	_, r.Err = client.Get(resourceURL(client, groupID, hookName), &r.Body, nil)
 	return
 }
 
 // List is a method to obtains a hook array of the autoscaling service.
 func List(client *golangsdk.ServiceClient, groupID string) (r ListResult) {
-	_, r.Err = client.Get(listURL(client, groupID), &r.Body, &golangsdk.RequestOpts{})
+	_, r.Err = client.Get(listURL(client, groupID), &r.Body, nil)
 	return
 }
 
@@ -88,7 +88,7 @@ func (opts UpdateOpts) ToLifecycleHookUpdateMap() (map[string]interface{}, error
 }
 
 // Update is a method which can be able to access to udpate the existing hook of the autoscaling service.
-func Update(client *golangsdk.ServiceClient, opts UpdateOptsBuilder, groupID, hookName string) (r GetResult) {
+func Update(client *golangsdk.ServiceClient, opts UpdateOptsBuilder, groupID, hookName string) (r UpdateResult) {
 	b, err := opts.ToLifecycleHookUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -102,7 +102,7 @@ func Update(client *golangsdk.ServiceClient, opts UpdateOptsBuilder, groupID, ho
 }
 
 //Delete is a method which can be able to access to delete the existing hook of the autoscaling service.
-func Delete(client *golangsdk.ServiceClient, groupID, hookName string) (r NoneResult) {
-	_, r.Err = client.Delete(resourceURL(client, groupID, hookName), &golangsdk.RequestOpts{})
+func Delete(client *golangsdk.ServiceClient, groupID, hookName string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, groupID, hookName), nil)
 	return
 }

--- a/openstack/autoscaling/v1/lifecyclehooks/requests.go
+++ b/openstack/autoscaling/v1/lifecyclehooks/requests.go
@@ -1,0 +1,108 @@
+package lifecyclehooks
+
+import "github.com/huaweicloud/golangsdk"
+
+// CreateOpts is a struct which will be used to create a lifecycle hook.
+type CreateOpts struct {
+	// The lifecycle hook name.
+	// The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 32 characters.
+	Name string `json:"lifecycle_hook_name" required:"true"`
+	// The lifecycle hook type.
+	// INSTANCE_TERMINATING: The hook suspends the instance when the instance is terminated.
+	// INSTANCE_LAUNCHING: The hook suspends the instance when the instance is started.
+	Type string `json:"lifecycle_hook_type" required:"true"`
+	// The default lifecycle hook callback operation: ABANDON and CONTINUE.
+	// By default, this operation is performed when the timeout duration expires.
+	DefaultResult string `json:"default_result,omitempty"`
+	// The lifecycle hook timeout duration, which ranges from 300 to 86400 in the unit of second.
+	// The default value is 3600.
+	Timeout int `json:"default_timeout,omitempty"`
+	// The unique topic in SMN.
+	// This parameter specifies a notification object for a lifecycle hook.
+	NotificationTopicURN string `json:"notification_topic_urn" required:"true"`
+	// The customized notification, which contains no more than 256 characters in length.
+	// The message cannot contain the following characters: <>&'().
+	NotificationMetadata string `json:"notification_metadata,omitempty"`
+}
+
+// CreateOptsBuilder is an interface by which can serialize the create parameters.
+type CreateOptsBuilder interface {
+	ToLifecycleHookCreateMap() (map[string]interface{}, error)
+}
+
+func (opts CreateOpts) ToLifecycleHookCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method which can be able to access to create the hook of autoscaling service.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder, groupID string) (r CreateResult) {
+	b, err := opts.ToLifecycleHookCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(rootURL(client, groupID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtains the hook detail of autoscaling service.
+func Get(client *golangsdk.ServiceClient, groupID, hookName string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, groupID, hookName), &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+// List is a method to obtains a hook array of the autoscaling service.
+func List(client *golangsdk.ServiceClient, groupID string) (r ListResult) {
+	_, r.Err = client.Get(listURL(client, groupID), &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+// UpdateOpts is a struct which will be used to update the existing hook.
+type UpdateOpts struct {
+	// The lifecycle hook type
+	Type string `json:"lifecycle_hook_type,omitempty"`
+	// The default lifecycle hook callback operation: ABANDON and CONTINUE.
+	// By default, this operation is performed when the timeout duration expires.
+	DefaultResult string `json:"default_result,omitempty"`
+	// The lifecycle hook timeout duration, which ranges from 300 to 86400 in the unit of second.
+	// The default value is 3600.
+	Timeout int `json:"default_timeout,omitempty"`
+	// The unique topic in SMN.
+	// This parameter specifies a notification object for a lifecycle hook.
+	NotificationTopicURN string `json:"notification_topic_urn,omitempty"`
+	// The customized notification, which contains no more than 256 characters in length.
+	// The message cannot contain the following characters: <>&'().
+	NotificationMetadata string `json:"notification_metadata,omitempty"`
+}
+
+// CreateOptsBuilder is an interface by which can serialize the create parameters
+type UpdateOptsBuilder interface {
+	ToLifecycleHookUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateOpts) ToLifecycleHookUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update is a method which can be able to access to udpate the existing hook of the autoscaling service.
+func Update(client *golangsdk.ServiceClient, opts UpdateOptsBuilder, groupID, hookName string) (r GetResult) {
+	b, err := opts.ToLifecycleHookUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(resourceURL(client, groupID, hookName), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+//Delete is a method which can be able to access to delete the existing hook of the autoscaling service.
+func Delete(client *golangsdk.ServiceClient, groupID, hookName string) (r NoneResult) {
+	_, r.Err = client.Delete(resourceURL(client, groupID, hookName), &golangsdk.RequestOpts{})
+	return
+}

--- a/openstack/autoscaling/v1/lifecyclehooks/results.go
+++ b/openstack/autoscaling/v1/lifecyclehooks/results.go
@@ -2,10 +2,6 @@ package lifecyclehooks
 
 import "github.com/huaweicloud/golangsdk"
 
-type commonResult struct {
-	golangsdk.Result
-}
-
 // Hook is a struct that represents the result of API calling.
 type Hook struct {
 	// The lifecycle hook name.
@@ -26,6 +22,17 @@ type Hook struct {
 	CreateTime string `json:"create_time"`
 }
 
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract will deserialize the result to Hook object.
+func (r commonResult) Extract() (*Hook, error) {
+	var s Hook
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
 type CreateResult struct {
 	commonResult
 }
@@ -34,11 +41,8 @@ type GetResult struct {
 	commonResult
 }
 
-// Extract will deserialize the result to Hook object.
-func (r commonResult) Extract() (*Hook, error) {
-	var s Hook
-	err := r.Result.ExtractInto(&s)
-	return &s, err
+type UpdateResult struct {
+	commonResult
 }
 
 type ListResult struct {
@@ -55,10 +59,6 @@ func (r ListResult) Extract() (*[]Hook, error) {
 	return &s.Hooks, err
 }
 
-type NoneResult struct {
-	commonResult
-}
-
-func (r NoneResult) Extract() error {
-	return r.Err
+type DeleteResult struct {
+	golangsdk.ErrResult
 }

--- a/openstack/autoscaling/v1/lifecyclehooks/results.go
+++ b/openstack/autoscaling/v1/lifecyclehooks/results.go
@@ -1,0 +1,64 @@
+package lifecyclehooks
+
+import "github.com/huaweicloud/golangsdk"
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Hook is a struct that represents the result of API calling.
+type Hook struct {
+	// The lifecycle hook name.
+	Name string `json:"lifecycle_hook_name"`
+	// The lifecycle hook type: INSTANCE_TERMINATING and INSTANCE_LAUNCHING.
+	Type string `json:"lifecycle_hook_type"`
+	// The default lifecycle hook callback operation: ABANDON and CONTINUE.
+	DefaultResult string `json:"default_result"`
+	// The lifecycle hook timeout duration in the unit of second.
+	Timeout int `json:"default_timeout"`
+	// The unique topic in SMN.
+	NotificationTopicURN string `json:"notification_topic_urn"`
+	// The topic name in SMN.
+	NotificationTopicName string `json:"notification_topic_name"`
+	// The notification message.
+	NotificationMetadata string `json:"notification_metadata"`
+	// The UTC-compliant time when the lifecycle hook is created.
+	CreateTime string `json:"create_time"`
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+// Extract will deserialize the result to Hook object.
+func (r commonResult) Extract() (*Hook, error) {
+	var s Hook
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
+type ListResult struct {
+	commonResult
+}
+
+// Extract will deserialize the result to Hook array.
+func (r ListResult) Extract() (*[]Hook, error) {
+	var s struct {
+		// An array of lifecycle hooks.
+		Hooks []Hook `json:"lifecycle_hooks"`
+	}
+	err := r.Result.ExtractInto(&s)
+	return &s.Hooks, err
+}
+
+type NoneResult struct {
+	commonResult
+}
+
+func (r NoneResult) Extract() error {
+	return r.Err
+}

--- a/openstack/autoscaling/v1/lifecyclehooks/testing/fixtures.go
+++ b/openstack/autoscaling/v1/lifecyclehooks/testing/fixtures.go
@@ -1,0 +1,156 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedGetResponse = `
+{
+	"lifecycle_hook_name": "test-hook",
+	"default_result": "ABANDON",
+	"default_timeout": 3600,
+	"notification_topic_urn": "urn:smn:regionId:b53e5554fad0494d96206fb84296510b:gsh",
+	"notification_topic_name": "gsh",
+	"lifecycle_hook_type": "INSTANCE_LAUNCHING",
+	"notification_metadata": null,
+	"create_time": "2019-03-18T16:00:11Z"
+}`
+
+	expectedUpdateResponse = `
+{
+	"lifecycle_hook_name": "test-hook",
+	"default_result": "CONTINUE",
+	"default_timeout": 3600,
+	"notification_topic_urn": "urn:smn:regionId:b53e5554fad0494d96206fb84296510b:gsh",
+	"notification_topic_name": "gsh",
+	"lifecycle_hook_type": "INSTANCE_LAUNCHING",
+	"notification_metadata": null,
+	"create_time": "2019-03-18T16:00:11Z"
+}`
+
+	expectedListResponse = `
+{
+	"lifecycle_hooks": [
+		{
+			"lifecycle_hook_name": "test-hook",
+			"default_result": "ABANDON",
+			"default_timeout": 3600,
+			"notification_topic_urn": "urn:smn:regionId:b53e5554fad0494d96206fb84296510b:gsh",
+			"notification_topic_name": "gsh",
+			"lifecycle_hook_type": "INSTANCE_LAUNCHING",
+			"notification_metadata": null,
+			"create_time": "2019-03-18T16:00:11Z"
+		}
+	]
+}`
+)
+
+var (
+	createOpts = lifecyclehooks.CreateOpts{
+		Name:                 "test-hook",
+		Type:                 "INSTANCE_LAUNCHING",
+		DefaultResult:        "ABANDON",
+		Timeout:              3600,
+		NotificationTopicURN: "urn:smn:regionId:b53e5554fad0494d96206fb84296510b:gsh",
+	}
+
+	expectedGetResponseData = &lifecyclehooks.Hook{
+		Name:                  "test-hook",
+		DefaultResult:         "ABANDON",
+		Type:                  "INSTANCE_LAUNCHING",
+		Timeout:               3600,
+		NotificationTopicURN:  "urn:smn:regionId:b53e5554fad0494d96206fb84296510b:gsh",
+		NotificationTopicName: "gsh",
+		NotificationMetadata:  "",
+		CreateTime:            "2019-03-18T16:00:11Z",
+	}
+
+	expectedListResponseData = &[]lifecyclehooks.Hook{
+		{
+			Name:                  "test-hook",
+			DefaultResult:         "ABANDON",
+			Type:                  "INSTANCE_LAUNCHING",
+			Timeout:               3600,
+			NotificationTopicURN:  "urn:smn:regionId:b53e5554fad0494d96206fb84296510b:gsh",
+			NotificationTopicName: "gsh",
+			NotificationMetadata:  "",
+			CreateTime:            "2019-03-18T16:00:11Z",
+		},
+	}
+
+	updateOpts = lifecyclehooks.UpdateOpts{
+		DefaultResult: "CONTINUE",
+	}
+
+	expectedUpdateResponseData = &lifecyclehooks.Hook{
+		Name:                  "test-hook",
+		DefaultResult:         "CONTINUE",
+		Type:                  "INSTANCE_LAUNCHING",
+		Timeout:               3600,
+		NotificationTopicURN:  "urn:smn:regionId:b53e5554fad0494d96206fb84296510b:gsh",
+		NotificationTopicName: "gsh",
+		NotificationMetadata:  "",
+		CreateTime:            "2019-03-18T16:00:11Z",
+	}
+)
+
+func handleLifeCycleHookCreate(t *testing.T) {
+	th.Mux.HandleFunc("/scaling_lifecycle_hook/50ed20b8-9853-4668-a71c-c8c15b5cb85f",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleLifeCycleHookGet(t *testing.T) {
+	th.Mux.HandleFunc("/scaling_lifecycle_hook/50ed20b8-9853-4668-a71c-c8c15b5cb85f/test-hook",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleLifeCycleHookList(t *testing.T) {
+	th.Mux.HandleFunc("/scaling_lifecycle_hook/50ed20b8-9853-4668-a71c-c8c15b5cb85f/list",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedListResponse)
+		})
+}
+
+func handleLifeCycleHookUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/scaling_lifecycle_hook/50ed20b8-9853-4668-a71c-c8c15b5cb85f/test-hook",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedUpdateResponse)
+		})
+}
+
+func handleLifeCycleHookDelete(t *testing.T) {
+	th.Mux.HandleFunc("/scaling_lifecycle_hook/50ed20b8-9853-4668-a71c-c8c15b5cb85f/test-hook",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNoContent)
+		})
+}

--- a/openstack/autoscaling/v1/lifecyclehooks/testing/requests_test.go
+++ b/openstack/autoscaling/v1/lifecyclehooks/testing/requests_test.go
@@ -53,6 +53,6 @@ func TestDeleteLifecycleHook(t *testing.T) {
 	defer th.TeardownHTTP()
 	handleLifeCycleHookDelete(t)
 
-	err := lifecyclehooks.Delete(client.ServiceClient(), "50ed20b8-9853-4668-a71c-c8c15b5cb85f", "test-hook").Extract()
+	err := lifecyclehooks.Delete(client.ServiceClient(), "50ed20b8-9853-4668-a71c-c8c15b5cb85f", "test-hook").ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/autoscaling/v1/lifecyclehooks/testing/requests_test.go
+++ b/openstack/autoscaling/v1/lifecyclehooks/testing/requests_test.go
@@ -1,0 +1,58 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateLifecycleHook(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleLifeCycleHookCreate(t)
+
+	actual, err := lifecyclehooks.Create(client.ServiceClient(), createOpts, "50ed20b8-9853-4668-a71c-c8c15b5cb85f").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestGetLifecycleHook(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleLifeCycleHookGet(t)
+
+	actual, err := lifecyclehooks.Get(client.ServiceClient(), "50ed20b8-9853-4668-a71c-c8c15b5cb85f", "test-hook").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestListLifecycleHook(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleLifeCycleHookList(t)
+
+	actual, err := lifecyclehooks.List(client.ServiceClient(), "50ed20b8-9853-4668-a71c-c8c15b5cb85f").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateLifecycleHook(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleLifeCycleHookUpdate(t)
+
+	actual, err := lifecyclehooks.Update(client.ServiceClient(), updateOpts, "50ed20b8-9853-4668-a71c-c8c15b5cb85f", "test-hook").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedUpdateResponseData, actual)
+}
+
+func TestDeleteLifecycleHook(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleLifeCycleHookDelete(t)
+
+	err := lifecyclehooks.Delete(client.ServiceClient(), "50ed20b8-9853-4668-a71c-c8c15b5cb85f", "test-hook").Extract()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/autoscaling/v1/lifecyclehooks/urls.go
+++ b/openstack/autoscaling/v1/lifecyclehooks/urls.go
@@ -1,0 +1,17 @@
+package lifecyclehooks
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "scaling_lifecycle_hook"
+
+func rootURL(client *golangsdk.ServiceClient, groupID string) string {
+	return client.ServiceURL(rootPath, groupID)
+}
+
+func resourceURL(client *golangsdk.ServiceClient, groupID, hookName string) string {
+	return client.ServiceURL(rootPath, groupID, hookName)
+}
+
+func listURL(client *golangsdk.ServiceClient, groupID string) string {
+	return client.ServiceURL(rootPath, groupID, "list")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
As the issue `Add Lifecycle hook resource suppoort for AS` of the Huaweicloud, we need to support related hook sdk.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. new lifecycle hook sdk supported:
  - Create
  - Get
  - List
  - Update
  - Delete
2. add test for lifecycle hook sdk.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateLifecycleHook
--- PASS: TestCreateLifecycleHook (0.00s)
=== RUN   TestGetLifecycleHook
--- PASS: TestGetLifecycleHook (0.00s)
=== RUN   TestListLifecycleHook
--- PASS: TestListLifecycleHook (0.00s)
=== RUN   TestUpdateLifecycleHook
--- PASS: TestUpdateLifecycleHook (0.00s)
=== RUN   TestDeleteLifecycleHook
--- PASS: TestDeleteLifecycleHook (0.01s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/testing        0.028s
```
