### PR TITLE
subnets: Allow DNS Nameservers to be cleared

### DIFF
--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -196,7 +196,7 @@ type UpdateOpts struct {
 	EnableDHCP    bool           `json:"dhcp_enable"`
 	PRIMARY_DNS   string         `json:"primary_dns,omitempty"`
 	SECONDARY_DNS string         `json:"secondary_dns,omitempty"`
-	DnsList       []string       `json:"dnsList,omitempty"`
+	DnsList       *[]string      `json:"dnsList,omitempty"`
 	ExtraDhcpOpts []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
 }
 

--- a/openstack/networking/v1/subnets/testing/requests_test.go
+++ b/openstack/networking/v1/subnets/testing/requests_test.go
@@ -69,11 +69,10 @@ func TestListSubnet(t *testing.T) {
 
 	expected := []subnets.Subnet{
 		{
-			Status:     "ACTIVE",
-			CIDR:       "192.168.200.0/24",
-			EnableDHCP: true,
-			Name:       "openlab-subnet",
-			//DnsList:          []string{},
+			Status:        "ACTIVE",
+			CIDR:          "192.168.200.0/24",
+			EnableDHCP:    true,
+			Name:          "openlab-subnet",
 			ID:            "0345a6ef-9404-487b-87c8-212557a1160d",
 			GatewayIP:     "192.168.200.1",
 			VPC_ID:        "58c24204-170e-4ff0-9b42-c53cdea9239a",
@@ -83,11 +82,10 @@ func TestListSubnet(t *testing.T) {
 			SubnetId:      "3d543273-31c3-41f8-b887-ed8c2c837578",
 		},
 		{
-			Status:     "ACTIVE",
-			CIDR:       "192.168.200.0/24",
-			EnableDHCP: true,
-			Name:       "openlab-subnet",
-			//DnsList:          []string{},
+			Status:        "ACTIVE",
+			CIDR:          "192.168.200.0/24",
+			EnableDHCP:    true,
+			Name:          "openlab-subnet",
 			ID:            "134ca339-24dc-44f5-ae6a-cf0404216ed2",
 			GatewayIP:     "192.168.200.1",
 			VPC_ID:        "58c24204-170e-4ff0-9b42-c53cdea9239a",
@@ -247,8 +245,12 @@ func TestUpdateSubnet(t *testing.T) {
 {
 "subnet":
     {
-    	"name": "testsubnet",
-		"dhcp_enable": false
+        "name": "testsubnet",
+        "dnsList": [
+            "114.114.114.114",
+            "8.8.8.8"
+        ],
+        "dhcp_enable": false
     }
 }
 `)
@@ -260,14 +262,17 @@ func TestUpdateSubnet(t *testing.T) {
 {
     "subnet": {
         "id": "83e3bddc-b9ed-4614-a0dc-8a997095a86c",
-		"name": "testsubnet",
+        "name": "testsubnet",
         "status": "ACTIVE"
     }
 }
 		`)
 	})
 
-	options := subnets.UpdateOpts{Name: "testsubnet"}
+	options := subnets.UpdateOpts{
+		Name:    "testsubnet",
+		DnsList: &[]string{"114.114.114.114", "8.8.8.8"},
+	}
 
 	n, err := subnets.Update(fake.ServiceClient(), "8f794f06-2275-4d82-9f5a-6d68fbe21a75", "83e3bddc-b9ed-4614-a0dc-8a997095a86c", options).Extract()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
$ go test -v ./
=== RUN   TestListSubnet
--- PASS: TestListSubnet (0.00s)
=== RUN   TestGetSubnet
--- PASS: TestGetSubnet (0.00s)
=== RUN   TestCreateSubnet
--- PASS: TestCreateSubnet (0.00s)
=== RUN   TestUpdateSubnet
--- PASS: TestUpdateSubnet (0.00s)
=== RUN   TestDeleteSubnet
--- PASS: TestDeleteSubnet (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets/testing        0.023s
```

