### PR TITLE
New cci pvc sdk supported

### DIFF
--- a/openstack/cci/v1/persistentvolumeclaims/requests.go
+++ b/openstack/cci/v1/persistentvolumeclaims/requests.go
@@ -1,0 +1,132 @@
+package persistentvolumeclaims
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type CreateOpts struct {
+	// The version of the persistent API, valid value is 'v1'.
+	ApiVersion string `json:"apiVersion" required:"true"`
+	// Kind is a string value representing the REST resource this object represents.
+	// Servers may infer this from the endpoint the client submits requests to.
+	Kind string `json:"kind" required:"true"`
+	// Standard object's metadata.
+	Metadata Metadata `json:"metadata" required:"true"`
+	// The desired characteristics of a volume.
+	Spec Spec `json:"spec" required:"true"`
+}
+
+type Metadata struct {
+	// The name of the persistent volume claim, must be unique within a namespace. Cannot be updated.
+	Name string `json:"name" required:"true"`
+	// Namespace defines the space within each name must be unique.
+	// An empty namespace is equivalent to the 'default' namespace, but 'default' is the canonical representation.
+	Namespace string `json:"namespace,omitempty"`
+	// An unstructured key value map stored with a resource that may be set by external tools to store and retrieve
+	// arbitrary metadata.
+	Annotations *Annotations `json:"annotations,omitempty"`
+}
+
+type Annotations struct {
+	// The type of the file system.
+	// The valid values are ext4 (EVS disk), obs (OBS bucket) and nfs (SFS or SFS Turbo).
+	FsType string `json:"fsType" required:"true"`
+	// ID of the volume
+	VolumeID string `json:"volumeID" required:"true"`
+	// The Shared path of the SFS and the SFS Turbo.
+	DeviceMountPath string `json:"deviceMountPath,omitempty"`
+}
+
+type Spec struct {
+	// Resources represents the minimum resources the volume should have.
+	Resources ResourceRequirement `json:"resources" required:"true"`
+	// Name of the storage class required by the claim.
+	// The following fields are supported:
+	//     EVS: sas, ssd and sata
+	//     SFS: nfs-rw
+	//     SFS Turbo: efs-performance and efs-standard
+	//     OBS: obs
+	StorageClassName string `json:"storageClassName" required:"true"`
+	// AccessModes contains the actual access modes the volume backing the PVC has.
+	//     ReadWriteOnce: can be mount read/write mode to exactly 1 host.
+	//     ReadOnlyMany: can be mount in read-only mode to many hosts.
+	//     ReadWriteMany: can be mount in read/write mode to many hosts.
+	AccessModes []string `json:"accessModes,omitempty"`
+}
+
+type ResourceRequirement struct {
+	// Minimum amount of compute resources required.
+	// If requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+	// otherwise to an implementation-defined value.
+	Requests *ResourceName `json:"requests,omitempty"`
+}
+
+type ResourceName struct {
+	// Volume size, in GB format: 'xGi'.
+	Storage string `json:"storage,omitempty"`
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToPVCCreateMap() (map[string]interface{}, error)
+}
+
+// ToPVCCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToPVCCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create accepts a CreateOpts struct and uses the namespace name to import a volume into the namespace.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder, ns string) (r CreateResult) {
+	reqBody, err := opts.ToPVCCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, ns), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+type ListOpts struct {
+	// Type of the storage, valid values are bs, obs, nfs and efs.
+	StorageType string `q:"storage_type"`
+}
+
+type ListOptsBuilder interface {
+	ToPVCListQuery() (string, error)
+}
+
+func (opts ListOpts) ToPVCListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of the persistent volume claims for specifies namespace.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder, ns string) pagination.Pager {
+	url := rootURL(client, ns)
+	if opts != nil {
+		query, err := opts.ToPVCListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return PersistentVolumeClaimPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete accepts to delete the specifies persistent volume claim form the namespace.
+func Delete(client *golangsdk.ServiceClient, ns, name string) (r DeleteResult) {
+	_, r.Err = client.DeleteWithBodyResp(resourceURL(client, ns, name), nil, r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/cci/v1/persistentvolumeclaims/results.go
+++ b/openstack/cci/v1/persistentvolumeclaims/results.go
@@ -1,0 +1,139 @@
+package persistentvolumeclaims
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type PersistentVolumeClaim struct {
+	Kind       string   `json:"kind"`
+	ApiVersion string   `json:"apiVersion"`
+	Metadata   MetaResp `json:"metadata"`
+	Spec       SpecResp `json:"spec"`
+	Status     Status   `json:"status"`
+}
+
+type MetaResp struct {
+	// The name of the Persistent Volume Claim.
+	Name string `json:"name"`
+	// The namespace where the Persistent Volume Claim is located.
+	Namespace string `json:"namespace"`
+	// An unstructured key value map stored with a resource that may be set by external tools to store and retrieve
+	// arbitrary metadata.
+	Annotations map[string]string `json:"annotations"`
+	// ID of the Persistent Volume Claim in UUID format.
+	UID string `json:"uid"`
+	// String that identifies the server's internal version of this object that can be used by clients to determine
+	// when objects have changed.
+	ResourceVersion string `json:"resourceVersion"`
+	// A timestamp representing the server time when this object was created.
+	CreationTimestamp string `json:"creationTimestamp"`
+	// SelfLink is a URL representing this object.
+	SelfLink string `json:"selfLink"`
+	// Map of string keys and values that can be used to organize and categorize (scope and select) objects.
+	Labels map[string]string `json:"labels"`
+	// Each finalizer string of array is an identifier for the responsible component that will remove the entry form
+	// the list.
+	Finalizers []string `json:"finalizers"`
+	// Enable identify whether the resource is available.
+	Enable bool `json:"enable"`
+}
+
+// The extra response of Persistent Volume are Capacity, FlexVolume, ClaimRef and PersistentVolumeReclaimPolicy.
+type SpecResp struct {
+	// The name of the volume.
+	VolumeName string `json:"volumeName"`
+	// AccessModes contains the actual access modes the volume backing the PVC has.
+	AccessModes []string `json:"accessModes"`
+	// Resources represents the minimum resources the volume should have.
+	Resources ResourceRequirement `json:"resources"`
+	// Name of the storage class required by the claim.
+	StorageClassName string `json:"storageClassName"`
+	// Mode of the volume.
+	VolumeMode string `json:"volumeMode"`
+	// The capacity of the storage.
+	Capacity ResourceName `json:"capacity"`
+	// PersistentVolumeClaim.
+	FlexVolume FlexVolume `json:"flexVolume"`
+	// Part of a bi-directional binding between persistentVolume and persistentVolumeClaim.
+	ClaimRef ClaimRef `json:"claimRef"`
+	// Specifies what happens to a persistent volume when released form its claim.
+	PersistentVolumeReclaimPolicy string `json:"persistentVolumeReclaimPolicy"`
+}
+
+type FlexVolume struct {
+	Driver  string  `json:"driver"`
+	FsType  string  `json:"fsType"`
+	Options Options `json:"options"`
+}
+
+type Options struct {
+	// The type of the file system.
+	FsType string `json:"fsType"`
+	// ID of the volume.
+	VolumeID string `json:"volumeID"`
+	// The Shared path of the SFS and the SFS Turbo.
+	DeviceMountPath string `json:"deviceMountPath"`
+}
+
+type ClaimRef struct {
+	// Kind of the referent.
+	Kind string `json:"kind"`
+	// Namespace of the referent.
+	Namespace string `json:"namespace"`
+	// Name of the referent.
+	Name string `json:"name"`
+	// UID of the referent.
+	UID string `json:"uid"`
+	// API version of the referent.
+	AapiVersion string `json:"apiVersion"`
+	// Specifies resource version to which this reference is made, If any.
+	ResourceVersion string `json:"resourceVersion"`
+}
+
+type Status struct {
+	// Phase represents the current phase of persistentVolumeClaim.
+	//     pending: used for PersistentVolumeClaims that are not yet bound.
+	//     Bound: used for PersistentVolumeClaims that are bound.
+	//     Lost: used for PersistentVolumeClaims that lost their underlying.
+	Phase string `json:"phase"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+func (r commonResult) Extract() (*PersistentVolumeClaim, error) {
+	var s PersistentVolumeClaim
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type ListResp struct {
+	PersistentVolumeClaim PersistentVolumeClaim `json:"persistentVolumeClaim"`
+	PersistentVolume      PersistentVolumeClaim `json:"persistentVolume"`
+}
+
+type PersistentVolumeClaimPage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractPersistentVolumeClaims(r pagination.Page) ([]ListResp, error) {
+	var s []ListResp
+	err := r.(PersistentVolumeClaimPage).Result.ExtractIntoSlicePtr(&s, "")
+	return s, err
+}
+
+type DeleteResult struct {
+	commonResult
+}
+
+func (r DeleteResult) Extract() ([]PersistentVolumeClaim, error) {
+	var s []PersistentVolumeClaim
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/openstack/cci/v1/persistentvolumeclaims/testing/fixtures.go
+++ b/openstack/cci/v1/persistentvolumeclaims/testing/fixtures.go
@@ -1,0 +1,349 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedRequest = `
+{
+	"apiVersion": "v1",
+	"kind": "PersistentVolumeClaim",
+	"metadata": {
+		"annotations": {
+			"fsType": "ext4",
+			"volumeID": "46d10433-35fb-459b-8482-2dd6fa192262"
+		},
+		"name": "cci-ssd-test-demo",
+		"namespace": "terraform-test"
+	},
+	"spec": {
+		"resources": {
+			"requests": {
+				"storage": "10Gi"
+			}
+		},
+		"storageClassName": "ssd"
+	}
+}`
+
+	expectedCreateResponse = `
+{
+	"kind": "PersistentVolumeClaim",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "cci-ssd-test-demo",
+		"namespace": "terraform-test",
+		"selfLink": "/api/v1/namespaces/terraform-test/persistentvolumeclaims/cci-ssd-test-demo",
+		"uid": "1ae26e9c-9e39-432d-9438-e6c669670629",
+		"resourceVersion": "285666212",
+		"creationTimestamp": "2021-05-25T03:45:45Z",
+		"labels": {
+			"failure-domain.beta.kubernetes.io/region": "cn-north-4",
+			"failure-domain.beta.kubernetes.io/zone": "cn-north-4a"
+		},
+		"annotations": {
+			"kubernetes.io/volumeId": "46d10433-35fb-459b-8482-2dd6fa192262"
+		},
+		"finalizers": [
+			"kubernetes.io/pvc-protection"
+		]
+	},
+	"spec": {
+		"accessModes": [
+			"ReadWriteMany"
+		],
+		"resources": {
+			"requests": {
+				"storage": "10Gi"
+			}
+		},
+		"volumeName": "cci-evs-import-46d10433-35fb-459b-8482-2dd6fa192262",
+		"storageClassName": "ssd",
+		"volumeMode": "Filesystem"
+	},
+	"status": {
+		"phase": "Pending"
+	}
+}`
+
+	expectedListResponse = `
+[
+	{
+		"persistentVolumeClaim": {
+			"metadata": {
+				"name": "cci-ssd-test-demo",
+				"namespace": "terraform-test",
+				"selfLink": "/api/v1/namespaces/terraform-test/persistentvolumeclaims/cci-ssd-test-demo",
+				"uid": "acf521b6-1e60-4ecd-af4a-671005e6d4bd",
+				"resourceVersion": "285728642",
+				"creationTimestamp": "2021-05-25T06:26:29Z",
+				"labels": {
+					"failure-domain.beta.kubernetes.io/region": "cn-north-4",
+					"failure-domain.beta.kubernetes.io/zone": "cn-north-4a"
+				},
+				"annotations": {
+					"kubernetes.io/volumeId": "45571ae3-125a-4cfa-bd76-a76eedcde45a"
+				},
+				"finalizers": [
+                    "kubernetes.io/pvc-protection"
+                ]
+			},
+			"spec": {
+				"accessModes": [
+					"ReadWriteMany"
+				],
+				"resources": {
+					"requests": {
+						"storage": "10Gi"
+					}
+				},
+				"volumeName": "cci-evs-import-45571ae3-125a-4cfa-bd76-a76eedcde45a",
+				"storageClassName": "ssd",
+				"volumeMode": "Filesystem"
+			},
+			"status": {
+				"phase": "Pending"
+			}
+		},
+		"persistentVolume": {
+			"metadata": {
+				"name": "cci-evs-import-45571ae3-125a-4cfa-bd76-a76eedcde45a",
+				"selfLink": "/api/v1/persistentvolumes/cci-evs-import-45571ae3-125a-4cfa-bd76-a76eedcde45a",
+				"uid": "e8dc63e5-014d-4e39-970c-5cc151e92144",
+				"resourceVersion": "285728644",
+				"creationTimestamp": "2021-05-25T06:26:29Z",
+				"labels": {
+					"failure-domain.beta.kubernetes.io/region": "cn-north-4",
+					"failure-domain.beta.kubernetes.io/zone": "cn-north-4a",
+					"tenant.kubernetes.io/domain-id": "0970d7b7d400f2470fbec00316a03560",
+					"tenant.kubernetes.io/project-id": "0970dd7a1300f5672ff2c003c60ae115"
+				},
+				"annotations": {
+					"kubernetes.io/createdby": "cci-apiserver",
+					"pv.kubernetes.io/bound-by-cci": "yes",
+					"pv.kubernetes.io/namespace": "terraform-test",
+					"tenant.kubernetes.io/domain-id": "0970d7b7d400f2470fbec00316a03560",
+					"tenant.kubernetes.io/project-id": "0970dd7a1300f5672ff2c003c60ae115"
+				},
+				"finalizers": [
+					"kubernetes.io/pv-protection"
+				]
+			},
+			"spec": {
+				"capacity": {
+					"storage": "10Gi"
+				},
+				"flexVolume": {
+					"driver": "huawei.com/fuxivol",
+					"fsType": "ext4",
+					"options": {
+						"fsType": "ext4",
+                        "storage_class": "ssd",
+						"volumeID": "45571ae3-125a-4cfa-bd76-a76eedcde45a"
+					}
+				},
+				"accessModes": [
+					"ReadWriteMany"
+				],
+				"claimRef": {
+					"namespace": "terraform-test",
+					"name": "cci-ssd-test-demo"
+				},
+				"persistentVolumeReclaimPolicy": "Delete",
+				"storageClassName": "ssd",
+				"volumeMode": "Filesystem"
+			},
+			"status": {
+				"phase": "Available"
+			}
+		}
+	}
+]`
+)
+
+var (
+	createOpts = &persistentvolumeclaims.CreateOpts{
+		ApiVersion: "v1",
+		Kind:       "PersistentVolumeClaim",
+		Metadata: persistentvolumeclaims.Metadata{
+			Name:      "cci-ssd-test-demo",
+			Namespace: "terraform-test",
+			Annotations: &persistentvolumeclaims.Annotations{
+				FsType:   "ext4",
+				VolumeID: "46d10433-35fb-459b-8482-2dd6fa192262",
+			},
+		},
+		Spec: persistentvolumeclaims.Spec{
+			Resources: persistentvolumeclaims.ResourceRequirement{
+				Requests: &persistentvolumeclaims.ResourceName{
+					Storage: "10Gi",
+				},
+			},
+			StorageClassName: "ssd",
+		},
+	}
+
+	expectedCreateResponseData = &persistentvolumeclaims.PersistentVolumeClaim{
+		Kind:       "PersistentVolumeClaim",
+		ApiVersion: "v1",
+		Metadata: persistentvolumeclaims.MetaResp{
+			Name:              "cci-ssd-test-demo",
+			Namespace:         "terraform-test",
+			SelfLink:          "/api/v1/namespaces/terraform-test/persistentvolumeclaims/cci-ssd-test-demo",
+			UID:               "1ae26e9c-9e39-432d-9438-e6c669670629",
+			ResourceVersion:   "285666212",
+			CreationTimestamp: "2021-05-25T03:45:45Z",
+			Annotations: map[string]string{
+				"kubernetes.io/volumeId": "46d10433-35fb-459b-8482-2dd6fa192262",
+			},
+			Labels: map[string]string{
+				"failure-domain.beta.kubernetes.io/region": "cn-north-4",
+				"failure-domain.beta.kubernetes.io/zone":   "cn-north-4a",
+			},
+			Finalizers: []string{
+				"kubernetes.io/pvc-protection",
+			},
+		},
+		Spec: persistentvolumeclaims.SpecResp{
+			AccessModes: []string{
+				"ReadWriteMany",
+			},
+			Resources: persistentvolumeclaims.ResourceRequirement{
+				Requests: &persistentvolumeclaims.ResourceName{
+					Storage: "10Gi",
+				},
+			},
+			VolumeName:       "cci-evs-import-46d10433-35fb-459b-8482-2dd6fa192262",
+			StorageClassName: "ssd",
+			VolumeMode:       "Filesystem",
+		},
+		Status: persistentvolumeclaims.Status{
+			Phase: "Pending",
+		},
+	}
+
+	listOpts = persistentvolumeclaims.ListOpts{
+		StorageType: "bs",
+	}
+
+	expectedListResponseData = []persistentvolumeclaims.ListResp{
+		{
+			PersistentVolumeClaim: persistentvolumeclaims.PersistentVolumeClaim{
+				Metadata: persistentvolumeclaims.MetaResp{
+					Name:              "cci-ssd-test-demo",
+					Namespace:         "terraform-test",
+					UID:               "acf521b6-1e60-4ecd-af4a-671005e6d4bd",
+					ResourceVersion:   "285728642",
+					SelfLink:          "/api/v1/namespaces/terraform-test/persistentvolumeclaims/cci-ssd-test-demo",
+					CreationTimestamp: "2021-05-25T06:26:29Z",
+					Annotations: map[string]string{
+						"kubernetes.io/volumeId": "45571ae3-125a-4cfa-bd76-a76eedcde45a",
+					},
+					Labels: map[string]string{
+						"failure-domain.beta.kubernetes.io/region": "cn-north-4",
+						"failure-domain.beta.kubernetes.io/zone":   "cn-north-4a",
+					},
+					Finalizers: []string{
+						"kubernetes.io/pvc-protection",
+					},
+				},
+				Spec: persistentvolumeclaims.SpecResp{
+					AccessModes: []string{
+						"ReadWriteMany",
+					},
+					Resources: persistentvolumeclaims.ResourceRequirement{
+						Requests: &persistentvolumeclaims.ResourceName{
+							Storage: "10Gi",
+						},
+					},
+					VolumeName:       "cci-evs-import-45571ae3-125a-4cfa-bd76-a76eedcde45a",
+					StorageClassName: "ssd",
+					VolumeMode:       "Filesystem",
+				},
+				Status: persistentvolumeclaims.Status{
+					Phase: "Pending",
+				},
+			},
+			PersistentVolume: persistentvolumeclaims.PersistentVolumeClaim{
+				Metadata: persistentvolumeclaims.MetaResp{
+					Name:              "cci-evs-import-45571ae3-125a-4cfa-bd76-a76eedcde45a",
+					UID:               "e8dc63e5-014d-4e39-970c-5cc151e92144",
+					SelfLink:          "/api/v1/persistentvolumes/cci-evs-import-45571ae3-125a-4cfa-bd76-a76eedcde45a",
+					ResourceVersion:   "285728644",
+					CreationTimestamp: "2021-05-25T06:26:29Z",
+					Annotations: map[string]string{
+						"kubernetes.io/createdby":         "cci-apiserver",
+						"pv.kubernetes.io/bound-by-cci":   "yes",
+						"pv.kubernetes.io/namespace":      "terraform-test",
+						"tenant.kubernetes.io/domain-id":  "0970d7b7d400f2470fbec00316a03560",
+						"tenant.kubernetes.io/project-id": "0970dd7a1300f5672ff2c003c60ae115",
+					},
+					Labels: map[string]string{
+						"failure-domain.beta.kubernetes.io/region": "cn-north-4",
+						"failure-domain.beta.kubernetes.io/zone":   "cn-north-4a",
+						"tenant.kubernetes.io/domain-id":           "0970d7b7d400f2470fbec00316a03560",
+						"tenant.kubernetes.io/project-id":          "0970dd7a1300f5672ff2c003c60ae115",
+					},
+					Finalizers: []string{
+						"kubernetes.io/pv-protection",
+					},
+				},
+				Spec: persistentvolumeclaims.SpecResp{
+					Capacity: persistentvolumeclaims.ResourceName{
+						Storage: "10Gi",
+					},
+					FlexVolume: persistentvolumeclaims.FlexVolume{
+						Driver: "huawei.com/fuxivol",
+						FsType: "ext4",
+						Options: persistentvolumeclaims.Options{
+							FsType:   "ext4",
+							VolumeID: "45571ae3-125a-4cfa-bd76-a76eedcde45a",
+						},
+					},
+					AccessModes: []string{
+						"ReadWriteMany",
+					},
+					ClaimRef: persistentvolumeclaims.ClaimRef{
+						Namespace: "terraform-test",
+						Name:      "cci-ssd-test-demo",
+					},
+					PersistentVolumeReclaimPolicy: "Delete",
+					StorageClassName:              "ssd",
+					VolumeMode:                    "Filesystem",
+				},
+				Status: persistentvolumeclaims.Status{
+					Phase: "Available",
+				},
+			},
+		},
+	}
+)
+
+func handlePersistentVolumeClaimCreate(t *testing.T) {
+	th.Mux.HandleFunc("/namespaces/terraform-test/extended-persistentvolumeclaims",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedCreateResponse)
+		})
+}
+
+func handlePersistentVolumeClaimList(t *testing.T) {
+	th.Mux.HandleFunc("/namespaces/terraform-test/extended-persistentvolumeclaims",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedListResponse)
+		})
+}

--- a/openstack/cci/v1/persistentvolumeclaims/testing/requests_test.go
+++ b/openstack/cci/v1/persistentvolumeclaims/testing/requests_test.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateOptsMarshall(t *testing.T) {
+	res, err := createOpts.ToPVCCreateMap()
+	th.AssertNoErr(t, err)
+	th.AssertJSONEquals(t, expectedRequest, res)
+}
+
+func TestCreateV1PersistentVolumeClaim(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handlePersistentVolumeClaimCreate(t)
+
+	actual, err := persistentvolumeclaims.Create(client.ServiceClient(), createOpts, "terraform-test").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestListV1PersistentVolumeClaim(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handlePersistentVolumeClaimList(t)
+
+	pages, err := persistentvolumeclaims.List(client.ServiceClient(), listOpts, "terraform-test").AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := persistentvolumeclaims.ExtractPersistentVolumeClaims(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}

--- a/openstack/cci/v1/persistentvolumeclaims/urls.go
+++ b/openstack/cci/v1/persistentvolumeclaims/urls.go
@@ -1,0 +1,13 @@
+package persistentvolumeclaims
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "namespaces"
+
+func rootURL(client *golangsdk.ServiceClient, ns string) string {
+	return client.ServiceURL(rootPath, ns, "extended-persistentvolumeclaims")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, ns, name string) string {
+	return client.ServiceURL(rootPath, ns, "persistentvolumeclaims", name)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To support the CCI persistent volume claims service, the pvc sdk should be added.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. new pvc sdk supported.
```

## Acceptance Steps Performed

```
go test -v -run Test
=== RUN   TestCreateOptsMarshall
--- PASS: TestCreateOptsMarshall (0.00s)
=== RUN   TestCreateV1PersistentVolumeClaim
--- PASS: TestCreateV1PersistentVolumeClaim (0.00s)
=== RUN   TestListV1PersistentVolumeClaim
--- PASS: TestListV1PersistentVolumeClaim (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/cci/v1/persistentvolumeclaims/testing        0.014s
```