### PR TITLE
obs: Add AvailableZone field into GetBucketMetadataOutput

### DIFF
--- a/openstack/obs/convert.go
+++ b/openstack/obs/convert.go
@@ -705,6 +705,9 @@ func ParseGetBucketMetadataOutput(output *GetBucketMetadataOutput) {
 	if ret, ok := output.ResponseHeaders[HEADER_EPID_HEADERS]; ok {
 		output.Epid = ret[0]
 	}
+	if ret, ok := output.ResponseHeaders[HEADER_AZ_REDUNDANCY]; ok {
+		output.AvailableZone = ret[0]
+	}
 	if ret, ok := output.ResponseHeaders[headerFSFileInterface]; ok {
 		output.FSStatus = parseStringToFSStatusType(ret[0])
 	} else {

--- a/openstack/obs/model.go
+++ b/openstack/obs/model.go
@@ -531,6 +531,7 @@ type GetBucketMetadataOutput struct {
 	MaxAgeSeconds int
 	ExposeHeader  string
 	Epid          string
+	AvailableZone string
 	FSStatus      FSStatusType
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

we can get AvailableZone field from HEADER_AZ_REDUNDANCY header.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

