### PR TITLE
New APIG dedicated instance v2 sdk and test

### DIFF
--- a/openstack/apigw/v2/instances/requests.go
+++ b/openstack/apigw/v2/instances/requests.go
@@ -1,0 +1,238 @@
+package instances
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// CreateOpts allows to create an APIG dedicated instance using given parameters.
+type CreateOpts struct {
+	// Name of the APIG dedicated instance. The name can contains of 3 to 64 characters.
+	Name string `json:"instance_name" required:"true"`
+	// Edition of the APIG dedicated instance. Currently, the editions are support:
+	// (IPv4): BASIC, PROFESSIONAL, ENTERPRISE, PLATINUM
+	// (IPv6): BASIC_IPV6, PROFESSIONAL_IPV6, ENTERPRISE_IPV6, PLATINUM_IPV6
+	Edition string `json:"spec_id" required:"true"`
+	// VPC ID.
+	VpcId string `json:"vpc_id" required:"true"`
+	// Subnet network ID.
+	SubnetId string `json:"subnet_id" required:"true"`
+	// ID of the security group to which the APIG dedicated instance belongs to.
+	SecurityGroupId string `json:"security_group_id" required:"true"`
+	// ID of the APIG dedicated instance, which will be automatically generated if you do not specify this parameter.
+	Id string `json:"instance_id,omitempty"`
+	// Description about the APIG dedicated instance.
+	Description string `json:"description,omitempty"`
+	// Start time of the maintenance time window in the format "xx:00:00".
+	// The value of xx can be 02, 06, 10, 14, 18, or 22.
+	MaintainBegin string `json:"maintain_begin,omitempty"`
+	// End time of the maintenance time window in the format "xx:00:00".
+	// There is a 4-hour difference between the start time and end time.
+	MaintainEnd string `json:"maintain_end,omitempty"`
+	// EIP ID.
+	EipId string `json:"eip_id,omitempty"`
+	// Outbound access bandwidth. This parameter is required if public outbound access is enabled for the APIG
+	// dedicated instance.
+	// Zero means turn off the egress access.
+	BandwidthSize int `json:"bandwidth_size"`
+	// Enterprise project ID. This parameter is required if you are using an enterprise account.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+	// AZs.
+	AvailableZoneIds []string `json:"available_zone_ids,omitempty"`
+	// Whether public access with an IPv6 address is supported.
+	Ipv6Enable bool `json:"ipv6_enable,omitempty"`
+}
+
+type CreateOptsBuilder interface {
+	ToInstanceCreateMap() (map[string]interface{}, error)
+}
+
+func (opts CreateOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a APIG dedicated instance.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToInstanceCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client), reqBody, &r.Body, nil)
+	return
+}
+
+// Get is a method to obtain the specified APIG dedicated instance according to the instance Id.
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// ID of the APIG dedicated instance.
+	Id string `q:"instance_id"`
+	// Name of the APIG dedicated instance.
+	Name string `q:"instance_name"`
+	// Instance status.
+	Status string `q:"status"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page.
+	Limit int `q:"limit"`
+}
+
+type ListOptsBuilder interface {
+	ToInstanceListQuery() (string, error)
+}
+
+func (opts ListOpts) ToInstanceListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more APIG dedicated instance according to the query parameters.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client)
+	if opts != nil {
+		query, err := opts.ToInstanceListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return InstancePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// UpdateOpts allows to update an existing APIG dedicated instance using given parameters.
+type UpdateOpts struct {
+	// Description about the APIG dedicated instance.
+	Description string `json:"description,omitempty"`
+	// Start time of the maintenance time window in the format "xx:00:00".
+	// The value of xx can be 02, 06, 10, 14, 18, or 22.
+	MaintainBegin string `json:"maintain_begin,omitempty"`
+	// End time of the maintenance time window in the format "xx:00:00".
+	// There is a 4-hour difference between the start time and end time.
+	MaintainEnd string `json:"maintain_end,omitempty"`
+	// Description about the APIG dedicated instance.
+	Name string `json:"instance_name,omitempty"`
+	// ID of the security group to which the APIG dedicated instance belongs to.
+	SecurityGroupId string `json:"security_group_id,omitempty"`
+}
+
+type UpdateOptsBuilder interface {
+	ToInstanceUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateOpts) ToInstanceUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update is a method by which to update an existing APIG dedicated instance.
+func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToInstanceUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, id), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete is a method to delete an existing APIG dedicated instance
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, id), nil)
+	return
+}
+
+// EgressAccessOpts allows the bandwidth size of an existing APIG dedicated instance to be updated with the given
+// parameters.
+type EgressAccessOpts struct {
+	// Outbound access bandwidth, in Mbit/s.
+	BandwidthSize string `json:"bandwidth_size,omitempty"`
+}
+
+type EgressAccessOptsBuilder interface {
+	ToEgressAccessMap() (map[string]interface{}, error)
+}
+
+func (opts EgressAccessOpts) ToEgressAccessMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// EnableEgressAccess is a method by which to enable the egress access of an existing APIG dedicated instance.
+func EnableEgressAccess(client *golangsdk.ServiceClient, id string, opts EgressAccessOptsBuilder) (r EnableEgressResult) {
+	reqBody, err := opts.ToEgressAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(egressURL(client, id), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+// UpdateEgressBandwidth is a method by which to update the egress bandwidth size of an existing APIG dedicated instance.
+func UpdateEgressBandwidth(client *golangsdk.ServiceClient, id string, opts EgressAccessOptsBuilder) (r UdpateEgressResult) {
+	reqBody, err := opts.ToEgressAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(egressURL(client, id), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// DisableEgressAccess is a method by which to disable the egress access of an existing APIG dedicated instance.
+func DisableEgressAccess(client *golangsdk.ServiceClient, id string) (r DisableEgressResult) {
+	_, r.Err = client.Delete(egressURL(client, id), nil)
+	return
+}
+
+// IngressAccessOpts allows binding and updating the eip associated with an existing APIG dedicated instance with the
+// given parameters.
+type IngressAccessOpts struct {
+	// EIP ID
+	EipId string `json:"eip_id,omitempty"`
+}
+
+type IngressAccessOptsBuilder interface {
+	ToEnableIngressAccessMap() (map[string]interface{}, error)
+}
+
+func (opts IngressAccessOpts) ToEnableIngressAccessMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// UpdateIngressAccess is a method to bind and update the eip associated with an existing APIG dedicated instance.
+func EnableIngressAccess(client *golangsdk.ServiceClient, id string, opts IngressAccessOptsBuilder) (r EnableIngressResult) {
+	reqBody, err := opts.ToEnableIngressAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(ingressURL(client, id), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// DisableIngressAccess is a method to unbind the eip associated with an existing APIG dedicated instance.
+func DisableIngressAccess(client *golangsdk.ServiceClient, id string) (r DisableIngressResult) {
+	_, r.Err = client.Delete(ingressURL(client, id), &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/apigw/v2/instances/results.go
+++ b/openstack/apigw/v2/instances/results.go
@@ -1,0 +1,242 @@
+package instances
+
+import (
+	"encoding/json"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// GetResult represents the result of a create operation.
+type CreateResult struct {
+	commonResult
+}
+
+type CreateResp struct {
+	Id      string `json:"instance_id"`
+	Message string `json:"message"`
+}
+
+//Call its Extract method to interpret it as a Instance Id.
+func (r CreateResult) Extract() (*CreateResp, error) {
+	var s CreateResp
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// GetResult represents the result of a Get operation.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a Update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+type Instance struct {
+	// Instance ID.
+	Id string `json:"id"`
+	// Project ID.
+	ProjectId string `json:"project_id"`
+	// Instance name.
+	Name string `json:"instance_name"`
+	// Instance status. The value are as following:
+	//   Creating, CreateSuccess, CreateFail, Initing, Registering, Running, InitingFailed, RegisterFailed, Installing
+	//   InstallFailed, Updating, UpdateFailed, Rollbacking, RollbackSuccess, RollbackFailed, Deleting, DeleteFailed
+	//   Unregistering, UnRegisterFailed, CreateTimeout, InitTimeout, RegisterTimeout, InstallTimeout, UpdateTimeout
+	//   RollbackTimeout, DeleteTimeout, UnregisterTimeout, Starting, Freezing, Frozen, Restarting, RestartFail
+	//   Unhealthy, RestartTimeout
+	// The status 'Deleting' is not supported, it's a BUG. --2021/06/15
+	Status string `json:"status"`
+	// Instance status ID.
+	//   1:Creating, 2:CreateSuccess, 3:CreateFail, 4:Initing, 5:Registering, 6:Running, 7:InitingFailed
+	//   8:RegisterFailed, 10:Installing, 11:InstallFailed, 12:Updating, 13:UpdateFailed, 20:Rollbacking
+	//   21:RollbackSuccess, 22:RollbackFailed, 23:Deleting, 24:DeleteFailed, 25:Unregistering, 26:UnRegisterFailed
+	//   27:CreateTimeout, 28:InitTimeout, 29:RegisterTimeout, 30:InstallTimeout, 31:UpdateTimeout
+	//   32:RollbackTimeout, 33:DeleteTimeout, 34:UnregisterTimeout, 35:Starting, 36:Freezing, 37:Frozen, 38:Restarting
+	//   39:RestartFail, 40:Unhealthy, 41:RestartTimeout
+	// Ditto: Issue of status id 23 (Deleting). --2021/06/15
+	StatusId int `json:"instance_status"`
+	// Instance type.
+	Type string `json:"type"`
+	// Instance edition.
+	Edition string `json:"spec"`
+	// Time when the APIG dedicated instance is created, in Unix timestamp format.
+	CreateTimestamp int64 `json:"create_time"`
+	// Enterprise project ID.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Billing mode of the APIG dedicated instance.
+	//   0:Pay per use
+	//   1:Pay per use
+	ChargeMode int `json:"charging_mode"`
+	// Yearly/Monthly subscription order ID.
+	CbcMetadata string `json:"cbc_metadata"`
+	// Description about the APIG dedicated instance.
+	Description string `json:"description"`
+	// VPC ID.
+	VpcId string `json:"vpc_id"`
+	// Subnet network ID.
+	SubnetId string `json:"subnet_id"`
+	// ID of the security group to which the APIG dedicated instance belongs to.
+	SecurityGroupId string `json:"security_group_id"`
+	// Start time of the maintenance time window in the format "xx:00:00".
+	MaintainBegin string `json:"maintain_begin"`
+	// End time of the maintenance time window in the format "xx:00:00".
+	MaintainEnd string `json:"maintain_end"`
+	// VPC ingress private address.
+	Ipv4VpcIngressAddress string `json:"ingress_ip"`
+	// VPC ingress private address (IPv6).
+	Ipv6VpcIngressAddress string `json:"ingress_ip_v6"`
+	// ID of the account to which the APIG dedicated instance belongs.
+	UserId string `json:"user_id"`
+	// EIP bound to the APIG dedicated instance.
+	Ipv4IngressEipAddress string `json:"eip_address"`
+	// EIP (IPv6).
+	Ipv6IngressEipAddress string `json:"eip_ipv6_address"`
+	// Public egress address (IPv6).
+	Ipv6EgressCidr string `json:"nat_eip_ipv6_cidr"`
+	// IP address for public outbound access.
+	Ipv4EgressAddress string `json:"nat_eip_address"`
+	// Outbound access bandwidth.
+	BandwidthSize int `json:"bandwidth_size"`
+	// AZs.
+	AvailableZoneIds string `json:"available_zone_ids"`
+	// Instance version.
+	Version string `json:"instance_version"`
+	// Supported features.
+	SupportedFeatures []string `json:"supported_features"`
+}
+
+// Call its Extract method to interpret it as a Instance.
+func (r commonResult) Extract() (*Instance, error) {
+	var s Instance
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type BaseInstance struct {
+	// Instance ID.
+	Id string `json:"id"`
+	// Project ID
+	ProjectId string `json:"project_id"`
+	// Instance name.
+	Name string `json:"instance_name"`
+	// Instance status. The value are as following:
+	//   Creating, CreateSuccess, CreateFail, Initing, Registering, Running, InitingFailed, RegisterFailed, Installing
+	//   InstallFailed, Updating, UpdateFailed, Rollbacking, RollbackSuccess, RollbackFailed, Deleting, DeleteFailed
+	//   Unregistering, UnRegisterFailed, CreateTimeout, InitTimeout, RegisterTimeout, InstallTimeout, UpdateTimeout
+	//   RollbackTimeout, DeleteTimeout, UnregisterTimeout, Starting, Freezing, Frozen, Restarting, RestartFail
+	//   Unhealthy, RestartTimeout
+	// Ditto: Issue of status 'Deleting'. --2021/06/15
+	Status string `json:"status"`
+	// Instance status ID.
+	//   1:Creating, 2:CreateSuccess, 3:CreateFail, 4:Initing, 5:Registering, 6:Running, 7:InitingFailed
+	//   8:RegisterFailed, 10:Installing, 11:InstallFailed, 12:Updating, 13:UpdateFailed, 20:Rollbacking
+	//   21:RollbackSuccess, 22:RollbackFailed, 23:Deleting, 24:DeleteFailed, 25:Unregistering, 26:UnRegisterFailed
+	//   27:CreateTimeout, 28:InitTimeout, 29:RegisterTimeout, 30:InstallTimeout, 31:UpdateTimeout
+	//   32:RollbackTimeout, 33:DeleteTimeout, 34:UnregisterTimeout, 35:Starting, 36:Freezing, 37:Frozen, 38:Restarting
+	//   39:RestartFail, 40:Unhealthy, 41:RestartTimeout
+	// Ditto: Issue of status id 23 (Deleting). --2021/06/15
+	StatusId int `json:"instance_status"`
+	// Instance type.
+	Type string `json:"type"`
+	// Instance edition.
+	Edition string `json:"spec"`
+	// Time when the APIG dedicated instance is created, in Unix timestamp format.
+	CreateTimestamp int64 `json:"create_time"`
+	// Enterprise project ID.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// EIP bound to the APIG dedicated instance.
+	Ipv4Address string `json:"eip_address"`
+	// Billing mode of the APIG dedicated instance.
+	//   0:Pay per use
+	//   1:Pay per use
+	ChargeMode int `json:"charging_mode"`
+	// Yearly/Monthly subscription order ID.
+	CbcMetadata string `json:"cbc_metadata"`
+}
+
+// InstancePage represents the result of a List operation.
+type InstancePage struct {
+	pagination.SinglePageBase
+}
+
+// Call its Extract method to interpret it as a BaseInstance array.
+func ExtractInstances(r pagination.Page) ([]BaseInstance, error) {
+	var s []BaseInstance
+	err := r.(InstancePage).Result.ExtractIntoSlicePtr(&s, "instances")
+	return s, err
+}
+
+// DeleteResult represents the result of a Delete operation.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+// EnableEgressResult represents the result of a EnableEgressAccess operation.
+type EnableEgressResult struct {
+	EgressResult
+}
+
+// UdpateEgressResult represents the result of a UpdateEgressBandwidth operation.
+type UdpateEgressResult struct {
+	EgressResult
+}
+
+type EgressResult struct {
+	golangsdk.Result
+}
+
+type Egress struct {
+	Id               string `json:"id"`
+	CloudEipId       string `json:"cloudEipId"`
+	CloudEipAddress  string `json:"cloudEipAddress"`
+	InstanceId       string `json:"instanceId"`
+	CloudBandwidthId string `json:"cloudBandwidthId"`
+	BandwidthName    string `json:"bandwidthName"`
+	BandwidthSize    int    `json:"bandwidthSize"`
+}
+
+// Call its Extract method to interpret it as a Egress.
+func (r EgressResult) Extract() (*Egress, error) {
+	var s Egress
+	if r.Err != nil {
+		return &s, r.Err
+	}
+	err := json.Unmarshal([]byte(r.Body.(string)), &s)
+	return &s, err
+}
+
+// DisableEgressResult represents the result of a DisableEgressAccess operation.
+type DisableEgressResult struct {
+	golangsdk.ErrResult
+}
+
+// EnableIngressResult represents the result of a EnableIngressAccess operation.
+type EnableIngressResult struct {
+	commonResult
+}
+
+type Ingress struct {
+	Id          string `json:"eip_id"`
+	EipAddress  string `json:"eip_address"`
+	Status      string `json:"eip_status"`
+	Ipv6Address string `json:"eip_ipv6_address"`
+}
+
+// Call its Extract method to interpret it as a Ingress.
+func (r EnableIngressResult) Extract() (*Ingress, error) {
+	var s Ingress
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// DisableIngressResult represents the result of a DisableIngressAccess operation.
+type DisableIngressResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/apigw/v2/instances/testing/fixtures.go
+++ b/openstack/apigw/v2/instances/testing/fixtures.go
@@ -1,0 +1,280 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedCreateRequest = `
+{
+	"available_zone_ids": [
+		"ap-southeast-2a",
+		"ap-southeast-2b"
+	],
+	"bandwidth_size": 6,
+	"description": "Created by script",
+	"eip_id": "9361e906-340d-4603-9e67-dadecc6c95ad",
+	"enterprise_project_id": "4a52b236-2644-4c10-b31c-7d53a58f75a3",
+	"instance_name": "terraform-test",
+	"maintain_begin": "22:00:00",
+	"maintain_end": "02:00:00",
+	"security_group_id": "0f3fa672-e3f1-4e8d-b4d1-d160d408eca8",
+	"spec_id": "BASIC",
+	"subnet_id": "8149c60b-939f-4eec-a667-6d40aa1e14df",
+	"vpc_id": "faf4d1ae-350a-45b5-9d4b-5754b6720cce"
+}`
+	expectedCreateResponse = `
+{
+	"instance_id": "e6a5871bfb5b47d19c5874790f639ef8"
+}`
+	expectedGetResponse = `
+{
+	"available_zone_ids": "[cn-north-4a]",
+	"bandwidth_size": 5,
+	"charging_mode": 0,
+	"create_time": 1623742314452,
+	"enterprise_project_id": "4a52b236-2644-4c10-b31c-7d53a58f75",
+	"id": "3fb0bdaa8b27480c971f78734497cd17",
+	"ingress_ip": "192.168.155.102",
+	"instance_name": "terraform-test",
+	"instance_status": 6,
+	"instance_version": "fe97b022e6cf401c9e6679f35cf7b130",
+	"maintain_begin": "22:00:00",
+	"maintain_end": "02:00:00",
+	"nat_eip_address": "94.74.112.175",
+	"security_group_id": "4b23c9b9-f941-477b-92f0-3adc6eb76124",
+	"spec": "BASIC",
+	"status": "Running",
+	"subnet_id": "7fd65ff0-3ccb-4756-a98c-e2bfe91d3c69",
+	"supported_features": [
+		"gateway_responses",
+		"ratelimit",
+		"request_body_size",
+		"backend_timeout",
+		"app_token",
+		"app_basic",
+		"app_secret",
+		"multi_auth",
+		"route",
+		"sign_basic",
+		"app_route",
+		"backend_client_certificate",
+		"ssl_ciphers",
+		"cors",
+		"app_quota",
+		"app_acl",
+		"real_ip_from_xff",
+		"set_resp_headers"
+	],
+	"user_id": "05602623488025011f3bc015b70b16c3",
+	"vpc_id": "1c105033-5b68-4cfe-b58b-b1000e517908"
+}`
+	expectedListResponse = `
+{
+	"instances": [
+		{
+			"charging_mode": 0,
+			"create_time": 1623816488875,
+			"eip_address": null,
+			"enterprise_project_id": "4a52b236-2644-4c10-b31c-7d53a58f75a3",
+			"id": "de379eed30aa4d31a84f426ea3c7ef4e",
+			"instance_name": "tf-acc-test-0616",
+			"instance_status": 6,
+			"project_id": "0581b95a0b8010e32f81c015009f6587",
+			"spec": "BASIC",
+			"status": "Running",
+			"type": "apig"
+		}
+	]
+}`
+	expectedUpdateIngressResponse = `
+{
+	"eip_address": "94.74.115.227",
+	"eip_id": "706673d2-e36b-4577-87bc-e6d6e71812f7",
+	"eip_status": "ACTIVE"
+}
+`
+)
+
+var (
+	createOpts = &instances.CreateOpts{
+		AvailableZoneIds:    []string{"ap-southeast-2a", "ap-southeast-2b"},
+		BandwidthSize:       6,
+		Description:         "Created by script",
+		EipId:               "9361e906-340d-4603-9e67-dadecc6c95ad",
+		EnterpriseProjectId: "4a52b236-2644-4c10-b31c-7d53a58f75a3",
+		Name:                "terraform-test",
+		MaintainBegin:       "22:00:00",
+		MaintainEnd:         "02:00:00",
+		SecurityGroupId:     "0f3fa672-e3f1-4e8d-b4d1-d160d408eca8",
+		Edition:             "BASIC",
+		SubnetId:            "8149c60b-939f-4eec-a667-6d40aa1e14df",
+		VpcId:               "faf4d1ae-350a-45b5-9d4b-5754b6720cce",
+	}
+
+	expectedCreateResponseData = &instances.CreateResp{
+		Id: "e6a5871bfb5b47d19c5874790f639ef8",
+	}
+
+	expectedListResponseData = []instances.BaseInstance{
+		{
+			ChargeMode:          0,
+			CreateTimestamp:     1623816488875,
+			EnterpriseProjectId: "4a52b236-2644-4c10-b31c-7d53a58f75a3",
+			Id:                  "de379eed30aa4d31a84f426ea3c7ef4e",
+			Name:                "tf-acc-test-0616",
+			StatusId:            6,
+			ProjectId:           "0581b95a0b8010e32f81c015009f6587",
+			Edition:             "BASIC",
+			Status:              "Running",
+			Type:                "apig",
+		},
+	}
+
+	updateOpts = instances.UpdateOpts{
+		Description:   "Updated by script",
+		Name:          "terraform-update",
+		MaintainBegin: "18:00:00",
+		MaintainEnd:   "22:00:00",
+	}
+
+	updateEgressOpts = instances.EgressAccessOpts{
+		BandwidthSize: "10",
+	}
+
+	updateIngressOpts = instances.IngressAccessOpts{
+		EipId: "706673d2-e36b-4577-87bc-e6d6e71812f7",
+	}
+
+	expectedUpdateIngressResponseData = &instances.Ingress{
+		ID:          "706673d2-e36b-4577-87bc-e6d6e71812f7",
+		Ipv4Address: "94.74.115.227",
+		Status:      "ACTIVE",
+	}
+
+	expectedGetResponseData = &instances.Instance{
+		AvailableZoneIds:      "[cn-north-4a]",
+		BandwidthSize:         5,
+		ChargeMode:            0,
+		CreateTimestamp:       1623742314452,
+		EnterpriseProjectId:   "4a52b236-2644-4c10-b31c-7d53a58f75",
+		Id:                    "3fb0bdaa8b27480c971f78734497cd17",
+		Ipv4VpcIngressAddress: "192.168.155.102",
+		Name:                  "terraform-test",
+		StatusId:              6,
+		Version:               "fe97b022e6cf401c9e6679f35cf7b130",
+		MaintainBegin:         "22:00:00",
+		MaintainEnd:           "02:00:00",
+		Ipv4EgressAddress:     "94.74.112.175",
+		SecurityGroupId:       "4b23c9b9-f941-477b-92f0-3adc6eb76124",
+		Edition:               "BASIC",
+		Status:                "Running",
+		SubnetId:              "7fd65ff0-3ccb-4756-a98c-e2bfe91d3c69",
+		SupportedFeatures: []string{
+			"gateway_responses",
+			"ratelimit",
+			"request_body_size",
+			"backend_timeout",
+			"app_token",
+			"app_basic",
+			"app_secret",
+			"multi_auth",
+			"route",
+			"sign_basic",
+			"app_route",
+			"backend_client_certificate",
+			"ssl_ciphers",
+			"cors",
+			"app_quota",
+			"app_acl",
+			"real_ip_from_xff",
+			"set_resp_headers",
+		},
+		VpcId:  "1c105033-5b68-4cfe-b58b-b1000e517908",
+		UserId: "05602623488025011f3bc015b70b16c3",
+	}
+)
+
+func handleV2InstanceCreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = fmt.Fprint(w, expectedCreateResponse)
+	})
+}
+
+func handleV2InstanceGet(t *testing.T) {
+	th.Mux.HandleFunc("/instances/e6a5871bfb5b47d19c5874790f639ef8", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedGetResponse)
+	})
+}
+
+func handleV2InstanceList(t *testing.T) {
+	th.Mux.HandleFunc("/instances", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedListResponse)
+	})
+}
+
+func handleV2InstanceUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/e6a5871bfb5b47d19c5874790f639ef8", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedGetResponse)
+	})
+}
+
+func handleV2InstanceDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/e6a5871bfb5b47d19c5874790f639ef8", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func handleV2InstanceEgressDisable(t *testing.T) {
+	th.Mux.HandleFunc("/instances/e6a5871bfb5b47d19c5874790f639ef8/nat-eip", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+		_, _ = fmt.Fprint(w, expectedGetResponse)
+	})
+}
+
+func handleV2InstanceIngressUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/e6a5871bfb5b47d19c5874790f639ef8/eip", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedUpdateIngressResponse)
+	})
+}
+
+func handleV2InstanceIngressDisable(t *testing.T) {
+	th.Mux.HandleFunc("/instances/e6a5871bfb5b47d19c5874790f639ef8/eip", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/apigw/v2/instances/testing/requests_test.go
+++ b/openstack/apigw/v2/instances/testing/requests_test.go
@@ -1,0 +1,89 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateV2Instance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2InstanceCreate(t)
+
+	actual, err := instances.Create(client.ServiceClient(), createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestGetV2Instance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2InstanceGet(t)
+
+	actual, err := instances.Get(client.ServiceClient(), "e6a5871bfb5b47d19c5874790f639ef8").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestListV2Instance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2InstanceList(t)
+
+	pages, err := instances.List(client.ServiceClient(), instances.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := instances.ExtractInstances(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV2Instance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2InstanceUpdate(t)
+
+	actual, err := instances.Update(client.ServiceClient(), "e6a5871bfb5b47d19c5874790f639ef8", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestDeleteV2Instance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2InstanceDelete(t)
+
+	err := instances.Delete(client.ServiceClient(), "e6a5871bfb5b47d19c5874790f639ef8").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestDisableEgressV2Instance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2InstanceEgressDisable(t)
+
+	err := instances.DisableEgressAccess(client.ServiceClient(), "e6a5871bfb5b47d19c5874790f639ef8").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestUpdateIngressV2Instance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2InstanceIngressUpdate(t)
+
+	actual, err := instances.UpdateIngressAccess(client.ServiceClient(), "e6a5871bfb5b47d19c5874790f639ef8",
+		updateIngressOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedUpdateIngressResponseData, actual)
+}
+
+func TestDisableIngressV2Instance(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2InstanceIngressDisable(t)
+
+	err := instances.DisableIngressAccess(client.ServiceClient(), "e6a5871bfb5b47d19c5874790f639ef8").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/apigw/v2/instances/urls.go
+++ b/openstack/apigw/v2/instances/urls.go
@@ -1,0 +1,21 @@
+package instances
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "instances"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id)
+}
+
+func egressURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id, "nat-eip")
+}
+
+func ingressURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id, "eip")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In order to support APIG dedicated instance resource, HuaweiCloud sdk needs to be added.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. new method of apig dedicated instance sdk supported:
  - Create
  - Get
  - List
  - Update
  - Delete
  - Enable egress access
  - Disable egress access
  - Update egress bandwidth size
  - Bind eip
  - Unbind eip
```

## Acceptance Steps Performed
```
go test -v -run Test=== RUN   TestCreateV2Instance
--- PASS: TestCreateV2Instance (0.00s)
=== RUN   TestGetV2Instance
--- PASS: TestGetV2Instance (0.00s)
=== RUN   TestListV2Instance
--- PASS: TestListV2Instance (0.00s)
=== RUN   TestUpdateV2Instance
--- PASS: TestUpdateV2Instance (0.00s)
=== RUN   TestDeleteV2Instance
--- PASS: TestDeleteV2Instance (0.00s)
=== RUN   TestDisableEgressV2Instance
--- PASS: TestDisableEgressV2Instance (0.00s)
=== RUN   TestUpdateIngressV2Instance
--- PASS: TestUpdateIngressV2Instance (0.00s)
=== RUN   TestDisableIngressV2Instance
--- PASS: TestDisableIngressV2Instance (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances/testing   0.019s
```
