### PR TITLE
New APIG group sdk and test

### DIFF
--- a/openstack/apigw/v2/apigroups/requests.go
+++ b/openstack/apigw/v2/apigroups/requests.go
@@ -1,0 +1,105 @@
+package apigroups
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// GroupOpts allows to create a group or update a existing group using given parameters.
+type GroupOpts struct {
+	// API group name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name" required:"true"`
+	// Description of the API group, which can contain a maximum of 255 characters,
+	// and the angle brackets (< and >) are not allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark,omitempty"`
+}
+
+type CreateOptsBuilder interface {
+	ToCreateOptsMap() (map[string]interface{}, error)
+}
+
+func (opts GroupOpts) ToCreateOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a new group.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts CreateOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToCreateOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method by which to create function that udpate a existing group.
+func Update(client *golangsdk.ServiceClient, instanceId, groupId string, opts CreateOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToCreateOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, groupId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtain the specified group according to the instanceId and appId.
+func Get(client *golangsdk.ServiceClient, instanceId, groupId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, groupId), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// API group ID.
+	Id string `q:"id"`
+	// API group name.
+	Name string `q:"name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+	// Parameter name for exact matching. Only API group names are supported.
+	PreciseSearch string `q:"precise_search"`
+}
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more groups according to the query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return GroupPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing group.
+func Delete(client *golangsdk.ServiceClient, instanceId, groupId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, groupId), nil)
+	return
+}

--- a/openstack/apigw/v2/apigroups/results.go
+++ b/openstack/apigw/v2/apigroups/results.go
@@ -1,0 +1,98 @@
+package apigroups
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Get operation.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+type Group struct {
+	// List of independent domain names bound to the API group.
+	UrlDomians []UrlDomian `json:"url_domains"`
+	// Time when the API group was last modified.
+	UpdateTime string `json:"update_time"`
+	// API group name.
+	Name string `json:"name"`
+	// Indicates whether the API group has been listed on the marketplace.
+	//     1: listed
+	//     2: not listed
+	//     3: under review.
+	OnSellStatus int `json:"on_sell_status"`
+	// Description.
+	Description string `json:"remark"`
+	// Subdomain name that API Gateway automatically allocates to the API group.
+	Subdomain string `json:"sl_domain"`
+	// Subdomain names that API Gateway automatically allocates to the API group.
+	Subdomains []string `json:"sl_domains"`
+	// ID.
+	Id string `json:"id"`
+	// Registraion time.
+	RegistraionTime string `json:"register_time"`
+	// group status.
+	//     1: valid
+	Status int `json:"status"`
+	// Indicates whether the API group is the default group.
+	IsDefault int `json:"is_default"`
+}
+
+type UrlDomian struct {
+	// Domain ID.
+	Id string `json:"id"`
+	// Domain ID.
+	DomainName string `json:"domain"`
+	// CNAME resolution status of the domain name.
+	//     1: not resolved
+	//     2: resolving
+	//     3: resolved
+	//     4: resolving failed
+	ResolutionStatus int `json:"cname_status"`
+	// SSL certificate ID.
+	SSLId string `json:"ssl_id"`
+	// SSL certificate name.
+	SSLName string `json:"ssl_name"`
+	// Minimum SSL version. TLS 1.1 and TLS 1.2 are supported.
+	// Enumeration values:
+	//     TLSv1.1
+	//     TLSv1.2
+	MinSSLVersion string `json:"min_ssl_version"`
+}
+
+func (r commonResult) Extract() (*Group, error) {
+	var s Group
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// GroupPage represents the response pages of the List operation.
+type GroupPage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractGroups(r pagination.Page) ([]Group, error) {
+	var s []Group
+	err := r.(GroupPage).Result.ExtractIntoSlicePtr(&s, "groups")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/apigw/v2/apigroups/testing/fixtures.go
+++ b/openstack/apigw/v2/apigroups/testing/fixtures.go
@@ -1,0 +1,177 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/apigroups"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedCreateResponse = `
+{
+	"id": "1c1acdd2f4d14eb886ecd2370cdb9c1a",
+	"is_default": 2,
+	"name": "terraform_test",
+	"on_sell_status": 2,
+	"register_time": "2021-06-22T07:02:20.133688796Z",
+	"remark": "Created by script",
+	"sl_domain": "1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com",
+	"sl_domains": [
+		"1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com"
+	],
+	"status": 1,
+	"update_time": "2021-06-22T07:02:20.133688906Z"
+}`
+
+	expectedListResponse = `
+{
+	"groups": [
+		{
+			"id": "1c1acdd2f4d14eb886ecd2370cdb9c1a",
+			"is_default": 2,
+			"name": "terraform_test",
+			"on_sell_status": 2,
+			"register_time": "2021-06-22T07:02:20.133688796Z",
+			"remark": "Created by script",
+			"sl_domain": "1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com",
+			"sl_domains": [
+				"1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com"
+			],
+			"status": 1,
+			"update_time": "2021-06-22T07:02:20.133688906Z"
+		}
+	]
+}`
+
+	expectedUpdateResponse = `
+{
+	"id": "1c1acdd2f4d14eb886ecd2370cdb9c1a",
+	"is_default": 2,
+	"name": "terraform_test_update",
+	"on_sell_status": 2,
+	"register_time": "2021-06-22T07:02:20.133688796Z",
+	"remark": "Updated by script",
+	"sl_domain": "1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com",
+	"sl_domains": [
+		"1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com"
+	],
+	"status": 1,
+	"update_time": "2021-06-22T07:02:20.133688906Z"
+}`
+)
+
+var (
+	createOpts = &apigroups.GroupOpts{
+		Name:        "terraform_test",
+		Description: "Created by script",
+	}
+
+	expectedCreateResponseData = &apigroups.Group{
+		Id:              "1c1acdd2f4d14eb886ecd2370cdb9c1a",
+		IsDefault:       2,
+		Name:            "terraform_test",
+		OnSellStatus:    2,
+		RegistraionTime: "2021-06-22T07:02:20.133688796Z",
+		Description:     "Created by script",
+		Subdomain:       "1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com",
+		Subdomains: []string{
+			"1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com",
+		},
+		Status:     1,
+		UpdateTime: "2021-06-22T07:02:20.133688906Z",
+	}
+
+	expectedUpdateResponseData = &apigroups.Group{
+		Id:              "1c1acdd2f4d14eb886ecd2370cdb9c1a",
+		IsDefault:       2,
+		Name:            "terraform_test_update",
+		OnSellStatus:    2,
+		RegistraionTime: "2021-06-22T07:02:20.133688796Z",
+		Description:     "Updated by script",
+		Subdomain:       "1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com",
+		Subdomains: []string{
+			"1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com",
+		},
+		Status:     1,
+		UpdateTime: "2021-06-22T07:02:20.133688906Z",
+	}
+
+	expectedListResponseData = []apigroups.Group{
+		{
+			Id:              "1c1acdd2f4d14eb886ecd2370cdb9c1a",
+			IsDefault:       2,
+			Name:            "terraform_test",
+			OnSellStatus:    2,
+			RegistraionTime: "2021-06-22T07:02:20.133688796Z",
+			Description:     "Created by script",
+			Subdomain:       "1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com",
+			Subdomains: []string{
+				"1c1acdd2f4d14eb886ecd2370cdb9c1a.apigw-cn-north-4-myhuaweicloud.com",
+			},
+			Status:     1,
+			UpdateTime: "2021-06-22T07:02:20.133688906Z",
+		},
+	}
+
+	updateOpts = apigroups.GroupOpts{
+		Name:        "terraform_test_update",
+		Description: "Updated by script",
+	}
+)
+
+func handleV2GroupCreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9750f26518a54da8bea1a7c41790c26d/api-groups",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = fmt.Fprint(w, expectedCreateResponse)
+		})
+}
+
+func handleV2GroupGet(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9750f26518a54da8bea1a7c41790c26d/api-groups/1c1acdd2f4d14eb886ecd2370cdb9c1a",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedCreateResponse)
+		})
+}
+
+func handleV2GroupList(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9750f26518a54da8bea1a7c41790c26d/api-groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedListResponse)
+	})
+}
+
+func handleV2GroupUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9750f26518a54da8bea1a7c41790c26d/api-groups/1c1acdd2f4d14eb886ecd2370cdb9c1a",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedUpdateResponse)
+		})
+}
+
+func handleV2GroupDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9750f26518a54da8bea1a7c41790c26d/api-groups/1c1acdd2f4d14eb886ecd2370cdb9c1a",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNoContent)
+		})
+}

--- a/openstack/apigw/v2/apigroups/testing/requests_test.go
+++ b/openstack/apigw/v2/apigroups/testing/requests_test.go
@@ -1,0 +1,60 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/apigroups"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateV2Group(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2GroupCreate(t)
+
+	actual, err := apigroups.Create(client.ServiceClient(), "9750f26518a54da8bea1a7c41790c26d", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestGetV2Group(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2GroupGet(t)
+
+	actual, err := apigroups.Get(client.ServiceClient(), "9750f26518a54da8bea1a7c41790c26d", "1c1acdd2f4d14eb886ecd2370cdb9c1a").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestListV2Group(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2GroupList(t)
+
+	pages, err := apigroups.List(client.ServiceClient(), "9750f26518a54da8bea1a7c41790c26d", apigroups.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := apigroups.ExtractGroups(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV2Group(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2GroupUpdate(t)
+
+	actual, err := apigroups.Update(client.ServiceClient(), "9750f26518a54da8bea1a7c41790c26d", "1c1acdd2f4d14eb886ecd2370cdb9c1a", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedUpdateResponseData, actual)
+}
+
+func TestDeleteV2Group(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2GroupDelete(t)
+
+	err := apigroups.Delete(client.ServiceClient(), "9750f26518a54da8bea1a7c41790c26d", "1c1acdd2f4d14eb886ecd2370cdb9c1a").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/apigw/v2/apigroups/urls.go
+++ b/openstack/apigw/v2/apigroups/urls.go
@@ -1,0 +1,13 @@
+package apigroups
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "instances"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(rootPath, instanceId, "api-groups")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, groupId string) string {
+	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- In order to support APIG service through terraform, HuaweiCloud sdk needs to be added.
- The APIG contains:
  - Dedicated instance
  - Application
  - **Group**
  - Environment
  - API
  - Domains
  - ACL
  - Request throttling policy
  - ...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. new method of apig application sdk supported:
  - Create
  - Get
  - List
  - Update
  - Delete
2. add test for each methods.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2Group
--- PASS: TestCreateV2Group (0.00s)
=== RUN   TestGetV2Group
--- PASS: TestGetV2Group (0.00s)
=== RUN   TestListV2Group
--- PASS: TestListV2Group (0.00s)
=== RUN   TestUpdateV2Group
--- PASS: TestUpdateV2Group (0.00s)
=== RUN   TestDeleteV2Group
--- PASS: TestDeleteV2Group (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/apigroups/testing   0.015s
```
