### PR TITLE
New APIG environment sdk and test

### DIFF
--- a/openstack/apigw/v2/environments/requests.go
+++ b/openstack/apigw/v2/environments/requests.go
@@ -1,0 +1,95 @@
+package environments
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// EnvironmentOpts allows to create a new environment or update an existing environment using given parameters.
+type EnvironmentOpts struct {
+	// Environment name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name" required:"true"`
+	// Description of the environment, which can contain a maximum of 255 characters,
+	// and the angle brackets (< and >) are not allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark,omitempty"`
+}
+
+type EnvironmentOptsBuilder interface {
+	ToEnvironmentOptsMap() (map[string]interface{}, error)
+}
+
+func (opts EnvironmentOpts) ToEnvironmentOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a new environment.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts EnvironmentOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToEnvironmentOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method by which to udpate an existing environment.
+func Update(client *golangsdk.ServiceClient, instanceId, envId string, opts EnvironmentOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToEnvironmentOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, envId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Environment name.
+	Name string `q:"name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+}
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more groups according to the query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return EnvironmentPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing group.
+func Delete(client *golangsdk.ServiceClient, instanceId, envId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, envId), nil)
+	return
+}

--- a/openstack/apigw/v2/environments/results.go
+++ b/openstack/apigw/v2/environments/results.go
@@ -1,0 +1,53 @@
+package environments
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update method.
+type UpdateResult struct {
+	commonResult
+}
+
+type Environment struct {
+	// Environment ID.
+	Id string `json:"id"`
+	// Environment name.
+	Name string `json:"name"`
+	// Description.
+	Description string `json:"remark"`
+	// Create time, in RFC-3339 format.
+	CreateTime string `json:"create_time"`
+}
+
+func (r commonResult) Extract() (*Environment, error) {
+	var s Environment
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// EnvironmentPage represents the response pages of the List method.
+type EnvironmentPage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractEnvironments(r pagination.Page) ([]Environment, error) {
+	var s []Environment
+	err := r.(EnvironmentPage).Result.ExtractIntoSlicePtr(&s, "envs")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/apigw/v2/environments/testing/fixtures.go
+++ b/openstack/apigw/v2/environments/testing/fixtures.go
@@ -1,0 +1,128 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedCreateResponse = `
+{
+	"create_time": "2021-06-22T12:11:28.18948645Z",
+	"id": "3585fce96a5d44f8b445121b9440274a",
+	"name": "terraform_test",
+	"remark": "Created by script"
+}`
+	expectedListResponse = `
+{
+	"envs": [
+		{
+			"create_time": "2020-10-14T16:15:19.417962Z",
+			"id": "DEFAULT_ENVIRONMENT_RELEASE_ID",
+			"name": "RELEASE",
+			"remark": "生产环境"
+		},
+		{
+			"create_time": "2021-06-22T11:40:18Z",
+			"id": "3585fce96a5d44f8b445121b9440274a",
+			"name": "terraform_test_update",
+			"remark": "Updated by script"
+		}
+	]
+}`
+	expectedUpdateResponse = `
+{
+	"create_time": "2021-06-22T11:40:18Z",
+	"id": "3585fce96a5d44f8b445121b9440274a",
+	"name": "terraform_test_update",
+	"remark": "Updated by script"
+}
+`
+)
+
+var (
+	createOpts = &environments.EnvironmentOpts{
+		Name:        "terraform_test",
+		Description: "Created by script",
+	}
+
+	expectedCreateResponseData = &environments.Environment{
+		Id:          "3585fce96a5d44f8b445121b9440274a",
+		Name:        "terraform_test",
+		Description: "Created by script",
+		CreateTime:  "2021-06-22T12:11:28.18948645Z",
+	}
+
+	updateOpts = &environments.EnvironmentOpts{
+		Name:        "terraform_test",
+		Description: "Created by script",
+	}
+
+	expectedUpdateResponseData = &environments.Environment{
+		Id:          "3585fce96a5d44f8b445121b9440274a",
+		Name:        "terraform_test_update",
+		Description: "Updated by script",
+		CreateTime:  "2021-06-22T11:40:18Z",
+	}
+
+	expectedListResponseData = []environments.Environment{
+		{
+			CreateTime:  "2020-10-14T16:15:19.417962Z",
+			Id:          "DEFAULT_ENVIRONMENT_RELEASE_ID",
+			Name:        "RELEASE",
+			Description: "生产环境",
+		},
+		{
+			CreateTime:  "2021-06-22T11:40:18Z",
+			Id:          "3585fce96a5d44f8b445121b9440274a",
+			Name:        "terraform_test_update",
+			Description: "Updated by script",
+		},
+	}
+)
+
+func handleV2EnvironmentCreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/envs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = fmt.Fprint(w, expectedCreateResponse)
+	})
+}
+
+func handleV2EnvironmentList(t *testing.T) {
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/envs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedListResponse)
+	})
+}
+
+func handleV2EnvironmentUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/envs/3585fce96a5d44f8b445121b9440274a",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedUpdateResponse)
+		})
+}
+
+func handleV2EnvironmentDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/envs/3585fce96a5d44f8b445121b9440274a",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNoContent)
+		})
+}

--- a/openstack/apigw/v2/environments/testing/requests_test.go
+++ b/openstack/apigw/v2/environments/testing/requests_test.go
@@ -1,0 +1,52 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateV2Environment(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2EnvironmentCreate(t)
+
+	actual, err := environments.Create(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestListV2Environment(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2EnvironmentList(t)
+
+	pages, err := environments.List(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52", environments.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := environments.ExtractEnvironments(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV2Environment(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2EnvironmentUpdate(t)
+
+	actual, err := environments.Update(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52",
+		"3585fce96a5d44f8b445121b9440274a", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedUpdateResponseData, actual)
+}
+
+func TestDeleteV2Environment(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2EnvironmentDelete(t)
+
+	err := environments.Delete(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52",
+		"3585fce96a5d44f8b445121b9440274a").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/apigw/v2/environments/urls.go
+++ b/openstack/apigw/v2/environments/urls.go
@@ -1,0 +1,13 @@
+package environments
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "instances"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(rootPath, instanceId, "envs")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, envId string) string {
+	return c.ServiceURL(rootPath, instanceId, "envs", envId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- In order to support APIG service through terraform, HuaweiCloud sdk needs to be added.
- The APIG contains:
  - Dedicated instance
  - Application
  - Group
  - **Environment**
  - API
  - Domains
  - ACL
  - Request throttling policy
  - ...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. new method of apig environment sdk supported:
  - Create
  - List
  - Update
  - Delete
2. add test for each methods.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2Environment
--- PASS: TestCreateV2Environment (0.00s)
=== RUN   TestListV2Environment
--- PASS: TestListV2Environment (0.00s)
=== RUN   TestUpdateV2Environment
--- PASS: TestUpdateV2Environment (0.00s)
=== RUN   TestDeleteV2Environment
--- PASS: TestDeleteV2Environment (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments/testing        0.013s
```