### PR TITLE
New APIG group responses sdk and test

### DIFF
--- a/openstack/apigw/v2/responses/requests.go
+++ b/openstack/apigw/v2/responses/requests.go
@@ -1,0 +1,164 @@
+package responses
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// CreateOpts allows to create a new custom response or update the existing custom response using given parameters.
+type ResponseOpts struct {
+	// APIG group name, which can contain 1 to 64 characters, only letters, digits, hyphens (-) and
+	// underscores (_) are allowed.
+	Name string `json:"name" required:"true"`
+	// Response type definition, which includes a key and value. Options of the key:
+	//     AUTH_FAILURE: Authentication failed.
+	//     AUTH_HEADER_MISSING: The identity source is missing.
+	//     AUTHORIZER_FAILURE: Custom authentication failed.
+	//     AUTHORIZER_CONF_FAILURE: There has been a custom authorizer error.
+	//     AUTHORIZER_IDENTITIES_FAILURE: The identity source of the custom authorizer is invalid.
+	//     BACKEND_UNAVAILABLE: The backend service is unavailable.
+	//     BACKEND_TIMEOUT: Communication with the backend service timed out.
+	//     THROTTLED: The request was rejected due to request throttling.
+	//     UNAUTHORIZED: The app you are using has not been authorized to call the API.
+	//     ACCESS_DENIED: Access denied.
+	//     NOT_FOUND: No API is found.
+	//     REQUEST_PARAMETERS_FAILURE: The request parameters are incorrect.
+	//     DEFAULT_4XX: Another 4XX error occurred.
+	//     DEFAULT_5XX: Another 5XX error occurred.
+	// Each error type is in JSON format.
+	Responses map[string]ResponseInfo `json:"responses,omitempty"`
+}
+
+type ResponseInfo struct {
+	// Response body template.
+	Body string `json:"body" required:"true"`
+	// HTTP status code of the response. If omitted, the status will be cancelled.
+	Status int `json:"status,omitempty"`
+	// Indicates whether the response is the default response.
+	// Only the response of the API call is supported.
+	IsDefault bool `json:"default,omitempty"`
+}
+
+type ResponseOptsBuilder interface {
+	ToResponseOptsMap() (map[string]interface{}, error)
+}
+
+func (opts ResponseOpts) ToResponseOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a new custom response.
+func Create(client *golangsdk.ServiceClient, instanceId, groupId string, opts ResponseOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToResponseOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId, groupId), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method by which to create function that udpate the existing custom response.
+func Update(client *golangsdk.ServiceClient, instanceId, groupId, respId string,
+	opts ResponseOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToResponseOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, groupId, respId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtain the specified custom response according to the instanceId, appId and respId.
+func Get(client *golangsdk.ServiceClient, instanceId, groupId, respId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, groupId, respId), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+}
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more custom reponses according to the query parameters.
+func List(client *golangsdk.ServiceClient, instanceId, groupId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId, groupId)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ResponsePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete the existing custom response.
+func Delete(client *golangsdk.ServiceClient, instanceId, groupId, respId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, groupId, respId), nil)
+	return
+}
+
+// SpecResp is used to build the APIG response url. All parameters are required.
+type SpecResp struct {
+	InstanceId string
+	GroupId    string
+	RespId     string
+	RespType   string
+}
+
+// GetSpecResp is a method to get the specifies custom response configuration from an group.
+func GetSpecResp(client *golangsdk.ServiceClient, spec SpecResp) (r GetSpecRespResult) {
+	_, r.Err = client.Get(responseURL(client, spec.InstanceId, spec.GroupId, spec.RespId, spec.RespType), &r.Body, nil)
+	return
+}
+
+type UpdateSpecRespBuilder interface {
+	ToSpecRespUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts ResponseInfo) ToSpecRespUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// UpdateSpecResp is a method to update an existing custom response configuration from an group.
+func UpdateSpecResp(client *golangsdk.ServiceClient, spec SpecResp, opts UpdateSpecRespBuilder) (r UpdateSpecRespResult) {
+	reqBody, err := opts.ToSpecRespUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(responseURL(client, spec.InstanceId, spec.GroupId, spec.RespId, spec.RespType),
+		reqBody, &r.Body, &golangsdk.RequestOpts{
+			OkCodes: []int{200},
+		})
+	return
+}
+
+// DeleteSpecResp is a method to delete an existing custom response configuration from an group.
+func DeleteSpecResp(client *golangsdk.ServiceClient, instanceId, groupId, respId, respType string) (r DeleteResult) {
+	_, r.Err = client.Delete(responseURL(client, instanceId, groupId, respId, respType), nil)
+	return
+}

--- a/openstack/apigw/v2/responses/results.go
+++ b/openstack/apigw/v2/responses/results.go
@@ -1,0 +1,100 @@
+package responses
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Get operation.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+type Response struct {
+	// Response ID.
+	Id string `json:"id"`
+	// Response name.
+	Name string `json:"name"`
+	// Response type definition, which includes a key and value. Options of the key:
+	//     AUTH_FAILURE: Authentication failed.
+	//     AUTH_HEADER_MISSING: The identity source is missing.
+	//     AUTHORIZER_FAILURE: Custom authentication failed.
+	//     AUTHORIZER_CONF_FAILURE: There has been a custom authorizer error.
+	//     AUTHORIZER_IDENTITIES_FAILURE: The identity source of the custom authorizer is invalid.
+	//     BACKEND_UNAVAILABLE: The backend service is unavailable.
+	//     BACKEND_TIMEOUT: Communication with the backend service timed out.
+	//     THROTTLED: The request was rejected due to request throttling.
+	//     UNAUTHORIZED: The app you are using has not been authorized to call the API.
+	//     ACCESS_DENIED: Access denied.
+	//     NOT_FOUND: No API is found.
+	//     REQUEST_PARAMETERS_FAILURE: The request parameters are incorrect.
+	//     DEFAULT_4XX: Another 4XX error occurred.
+	//     DEFAULT_5XX: Another 5XX error occurred.
+	// Each error type is in JSON format.
+	Responses map[string]ResponseInfo `json:"responses"`
+	// Indicates whether the group response is the default response.
+	IsDefault bool `json:"default"`
+	// Creation time.
+	CreateTime string `json:"create_time"`
+	// Update time.
+	UpdateTime string `json:"update_time"`
+}
+
+// Extract is a method to extract an response struct.
+func (r commonResult) Extract() (*Response, error) {
+	var s Response
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ResponsePage represents the response pages of the List operation.
+type ResponsePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractResponses is a method to extract an response struct list.
+func ExtractResponses(r pagination.Page) ([]Response, error) {
+	var s []Response
+	err := r.(ResponsePage).Result.ExtractIntoSlicePtr(&s, "responses")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete and DeleteSpecResp method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type SpecRespResult struct {
+	commonResult
+}
+
+// GetSpecRespResult represents a result of the GetSpecResp method.
+type GetSpecRespResult struct {
+	SpecRespResult
+}
+
+// UpdateSpecRespResult represents a result of the UpdateSpecResp method.
+type UpdateSpecRespResult struct {
+	SpecRespResult
+}
+
+// ExtractSpecResp is a method to extract an response struct using a specifies key.
+func (r SpecRespResult) ExtractSpecResp(key string) (*ResponseInfo, error) {
+	var s ResponseInfo
+	err := r.ExtractIntoStructPtr(&s, key)
+	return &s, err
+}

--- a/openstack/apigw/v2/responses/testing/fixtures.go
+++ b/openstack/apigw/v2/responses/testing/fixtures.go
@@ -1,0 +1,327 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedCreateResponse = `
+{
+	"create_time": "2021-06-24T09:33:10.562277766+08:00",
+	"default": false,
+	"id": "baabc69fdb8f4c458637666c0441e9a4",
+	"name": "terraform-test",
+	"responses": {
+		"ACCESS_DENIED": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": false,
+			"status": 402
+		},
+		"AUTHORIZER_CONF_FAILURE": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 500
+		},
+		"AUTHORIZER_FAILURE": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 500
+		},
+		"AUTHORIZER_IDENTITIES_FAILURE": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 401
+		},
+		"AUTH_FAILURE": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 401
+		},
+		"AUTH_HEADER_MISSING": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 401
+		},
+		"BACKEND_TIMEOUT": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 504
+		},
+		"BACKEND_UNAVAILABLE": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 502
+		},
+		"DEFAULT_4XX": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true
+		},
+		"DEFAULT_5XX": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true
+		},
+		"NOT_FOUND": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 404
+		},
+		"REQUEST_PARAMETERS_FAILURE": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 400
+		},
+		"THROTTLED": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 429
+		},
+		"UNAUTHORIZED": {
+			"body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+			"default": true,
+			"status": 401
+		}
+	},
+	"update_time": "2021-06-24T09:33:10.562277766+08:00"
+}`
+	expectedListResponse = `
+{
+	"responses": [
+        {
+            "id": "baabc69fdb8f4c458637666c0441e9a4",
+            "name": "terraform-test",
+            "default": false,
+            "create_time": "2021-06-24T01:33:10Z",
+            "update_time": "2021-06-24T01:33:10Z"
+        },
+        {
+            "id": "5623b9b3c2154f6ab1a7c0cf5c7c6278",
+            "name": "default",
+            "default": true,
+            "create_time": "2021-06-23T08:29:23Z",
+            "update_time": "2021-06-23T08:29:23Z"
+        }
+    ]
+}`
+	expectedGetSpecResponse = `
+{
+	"ACCESS_DENIED": {
+        "body": "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+        "default": false,
+        "status": 405
+    }
+}`
+)
+
+var (
+	createOpts = &responses.ResponseOpts{
+		Name: "terraform-test",
+		Responses: map[string]responses.ResponseInfo{
+			"ACCESS_DENIED": {
+				Body:   "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				Status: 402,
+			},
+		},
+	}
+
+	expectedCreateResponseData = &responses.Response{
+		CreateTime: "2021-06-24T09:33:10.562277766+08:00",
+		UpdateTime: "2021-06-24T09:33:10.562277766+08:00",
+		IsDefault:  false,
+		Id:         "baabc69fdb8f4c458637666c0441e9a4",
+		Name:       "terraform-test",
+		Responses: map[string]responses.ResponseInfo{
+			"ACCESS_DENIED": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: false,
+				Status:    402,
+			},
+			"AUTHORIZER_CONF_FAILURE": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    500,
+			},
+			"AUTHORIZER_FAILURE": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    500,
+			},
+			"AUTHORIZER_IDENTITIES_FAILURE": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    401,
+			},
+			"AUTH_FAILURE": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    401,
+			},
+			"AUTH_HEADER_MISSING": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    401,
+			},
+			"BACKEND_TIMEOUT": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    504,
+			},
+			"BACKEND_UNAVAILABLE": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    502,
+			},
+			"DEFAULT_4XX": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+			},
+			"DEFAULT_5XX": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+			},
+			"NOT_FOUND": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    404,
+			},
+			"REQUEST_PARAMETERS_FAILURE": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    400,
+			},
+			"THROTTLED": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    429,
+			},
+			"UNAUTHORIZED": {
+				Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+				IsDefault: true,
+				Status:    401,
+			},
+		},
+	}
+
+	expectedListResponseData = []responses.Response{
+		{
+			Id:         "baabc69fdb8f4c458637666c0441e9a4",
+			Name:       "terraform-test",
+			IsDefault:  false,
+			CreateTime: "2021-06-24T01:33:10Z",
+			UpdateTime: "2021-06-24T01:33:10Z",
+		},
+		{
+			Id:         "5623b9b3c2154f6ab1a7c0cf5c7c6278",
+			Name:       "default",
+			IsDefault:  true,
+			CreateTime: "2021-06-23T08:29:23Z",
+			UpdateTime: "2021-06-23T08:29:23Z",
+		},
+	}
+
+	updateOpts = &responses.ResponseOpts{
+		Name: "terraform-test",
+	}
+
+	expectedGetSpecResponseData = &responses.ResponseInfo{
+		Body:      "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+		Status:    405,
+		IsDefault: false,
+	}
+
+	updateSpecRespOpts = responses.ResponseInfo{
+		Body:   "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+		Status: 405,
+	}
+)
+
+func handleV2ResponsesCreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9b76174b785342078e557f23c01d5e41/api-groups/d060ade0560a4c01b89bf954ad2e9d6e"+
+		"/gateway-responses", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = fmt.Fprint(w, expectedCreateResponse)
+	})
+}
+
+func handleV2ResponsesGet(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9b76174b785342078e557f23c01d5e41/api-groups/d060ade0560a4c01b89bf954ad2e9d6e"+
+		"/gateway-responses/baabc69fdb8f4c458637666c0441e9a4", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedCreateResponse)
+	})
+}
+
+func handleV2ResponsesList(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9b76174b785342078e557f23c01d5e41/api-groups/d060ade0560a4c01b89bf954ad2e9d6e"+
+		"/gateway-responses", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedListResponse)
+	})
+}
+
+func handleV2ResponsesUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9b76174b785342078e557f23c01d5e41/api-groups/d060ade0560a4c01b89bf954ad2e9d6e"+
+		"/gateway-responses/baabc69fdb8f4c458637666c0441e9a4", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedCreateResponse)
+	})
+}
+
+func handleV2ResponsesDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9b76174b785342078e557f23c01d5e41/api-groups/d060ade0560a4c01b89bf954ad2e9d6e"+
+		"/gateway-responses/baabc69fdb8f4c458637666c0441e9a4", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func handleV2SpecResponseGet(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9b76174b785342078e557f23c01d5e41/api-groups/d060ade0560a4c01b89bf954ad2e9d6e"+
+		"/gateway-responses/baabc69fdb8f4c458637666c0441e9a4/ACCESS_DENIED", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedGetSpecResponse)
+	})
+}
+
+func handleV2SpecResponseUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9b76174b785342078e557f23c01d5e41/api-groups/d060ade0560a4c01b89bf954ad2e9d6e"+
+		"/gateway-responses/baabc69fdb8f4c458637666c0441e9a4/ACCESS_DENIED", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedGetSpecResponse)
+	})
+}
+
+func handleV2SpecResponseDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/9b76174b785342078e557f23c01d5e41/api-groups/d060ade0560a4c01b89bf954ad2e9d6e"+
+		"/gateway-responses/baabc69fdb8f4c458637666c0441e9a4/ACCESS_DENIED", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/apigw/v2/responses/testing/requests_test.go
+++ b/openstack/apigw/v2/responses/testing/requests_test.go
@@ -1,0 +1,111 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/responses"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateV2Responses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ResponsesCreate(t)
+
+	actual, err := responses.Create(client.ServiceClient(), "9b76174b785342078e557f23c01d5e41",
+		"d060ade0560a4c01b89bf954ad2e9d6e", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestGetV2Responses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ResponsesGet(t)
+
+	actual, err := responses.Get(client.ServiceClient(), "9b76174b785342078e557f23c01d5e41",
+		"d060ade0560a4c01b89bf954ad2e9d6e", "baabc69fdb8f4c458637666c0441e9a4").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestListV2Responses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ResponsesList(t)
+
+	pages, err := responses.List(client.ServiceClient(), "9b76174b785342078e557f23c01d5e41",
+		"d060ade0560a4c01b89bf954ad2e9d6e", responses.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := responses.ExtractResponses(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV2Responses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ResponsesUpdate(t)
+
+	actual, err := responses.Update(client.ServiceClient(), "9b76174b785342078e557f23c01d5e41",
+		"d060ade0560a4c01b89bf954ad2e9d6e", "baabc69fdb8f4c458637666c0441e9a4", updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestDeleteV2Responses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ResponsesDelete(t)
+
+	err := responses.Delete(client.ServiceClient(), "9b76174b785342078e557f23c01d5e41",
+		"d060ade0560a4c01b89bf954ad2e9d6e", "baabc69fdb8f4c458637666c0441e9a4").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestGetV2SpecResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2SpecResponseGet(t)
+
+	specResp := responses.SpecResp{
+		InstanceId: "9b76174b785342078e557f23c01d5e41",
+		GroupId:    "d060ade0560a4c01b89bf954ad2e9d6e",
+		RespId:     "baabc69fdb8f4c458637666c0441e9a4",
+		RespType:   "ACCESS_DENIED",
+	}
+	actual, err := responses.GetSpecResp(client.ServiceClient(), specResp).ExtractSpecResp("ACCESS_DENIED")
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetSpecResponseData, actual)
+}
+
+func TestUpdateV2SpecResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2SpecResponseUpdate(t)
+	specResp := responses.SpecResp{
+		InstanceId: "9b76174b785342078e557f23c01d5e41",
+		GroupId:    "d060ade0560a4c01b89bf954ad2e9d6e",
+		RespId:     "baabc69fdb8f4c458637666c0441e9a4",
+		RespType:   "ACCESS_DENIED",
+	}
+	opt := responses.ResponseInfo{
+		Body:   "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\",\"request_id\":\"$context.requestId\"}",
+		Status: 405,
+	}
+	actual, err := responses.UpdateSpecResp(client.ServiceClient(), specResp,
+		opt).ExtractSpecResp("ACCESS_DENIED")
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetSpecResponseData, actual)
+}
+
+func TestDeleteV2SpecResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2SpecResponseDelete(t)
+
+	err := responses.DeleteSpecResp(client.ServiceClient(), "9b76174b785342078e557f23c01d5e41",
+		"d060ade0560a4c01b89bf954ad2e9d6e", "baabc69fdb8f4c458637666c0441e9a4", "ACCESS_DENIED").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/apigw/v2/responses/urls.go
+++ b/openstack/apigw/v2/responses/urls.go
@@ -1,0 +1,17 @@
+package responses
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "instances"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId, groupId string) string {
+	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId, "gateway-responses")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, groupId, respId string) string {
+	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId, "gateway-responses", respId)
+}
+
+func responseURL(c *golangsdk.ServiceClient, instanceId, groupId, respId, respType string) string {
+	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId, "gateway-responses", respId, respType)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- In order to support APIG service through terraform, HuaweiCloud sdk needs to be added.
- The APIG contains:
  - Dedicated instance
  - Application
  - Group
  - **Responses**
  - Environment
  - API
  - Domains
  - ACL
  - Request throttling policy
  - ...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. new method of apig group responses sdk supported:
  - Create
  - Get
  - List
  - Update
  - Delete
  - Update specifies response
  - Get specifies response
  - Delete specifies response
2. add test for each methods.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2GroupResponse
--- PASS: TestCreateV2GroupResponse (0.00s)
=== RUN   TestGetV2GroupResponse
--- PASS: TestGetV2GroupResponse (0.00s)
=== RUN   TestListV2GroupResponse
--- PASS: TestListV2GroupResponse (0.00s)
=== RUN   TestUpdateV2GroupResponse
--- PASS: TestUpdateV2GroupResponse (0.00s)
=== RUN   TestDeleteV2GroupResponse
--- PASS: TestDeleteV2GroupResponse (0.00s)
=== RUN   TestGetV2GroupSpecResponse
--- PASS: TestGetV2GroupSpecResponse (0.00s)
=== RUN   TestUpdateV2GroupSpecResponse
--- PASS: TestUpdateV2GroupSpecResponse (0.00s)
=== RUN   TestDeleteV2GroupSpecResponse
--- PASS: TestDeleteV2GroupSpecResponse (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/groupresponses/testing       0.030s
```