### PR TITLE
New APIG environment variables sdk and test

### DIFF
--- a/openstack/apigw/v2/environments/requests.go
+++ b/openstack/apigw/v2/environments/requests.go
@@ -32,7 +32,7 @@ func Create(client *golangsdk.ServiceClient, instanceId string, opts Environment
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	_, r.Err = client.Post(rootURL(client, instanceId, "envs"), reqBody, &r.Body, nil)
 	return
 }
 
@@ -43,7 +43,7 @@ func Update(client *golangsdk.ServiceClient, instanceId, envId string, opts Envi
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Put(resourceURL(client, instanceId, envId), reqBody, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Put(resourceURL(client, instanceId, "envs", envId), reqBody, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return
@@ -74,7 +74,7 @@ func (opts ListOpts) ToListQuery() (string, error) {
 
 // List is a method to obtain an array of one or more groups according to the query parameters.
 func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
-	url := rootURL(client, instanceId)
+	url := rootURL(client, instanceId, "envs")
 	if opts != nil {
 		query, err := opts.ToListQuery()
 		if err != nil {
@@ -90,6 +90,99 @@ func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuild
 
 // Delete is a method to delete an existing group.
 func Delete(client *golangsdk.ServiceClient, instanceId, envId string) (r DeleteResult) {
-	_, r.Err = client.Delete(resourceURL(client, instanceId, envId), nil)
+	_, r.Err = client.Delete(resourceURL(client, instanceId, "envs", envId), nil)
+	return
+}
+
+// CreateVariableOpts allows to create a new envirable variable for an existing group using given parameters.
+type CreateVariableOpts struct {
+	// Variable name, which can contain 3 to 32 characters, starting with a letter.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	// In the definition of an API, #Name# (case-sensitive) indicates a variable.
+	// It is replaced by the actual value when the API is published in an environment.
+	Name string `json:"variable_name" required:"true"`
+	// Variable value, which can contain 1 to 255 characters.
+	// Only letters, digits, and special characters (_-/.:) are allowed.
+	Value string `json:"variable_value" required:"true"`
+	// Environment ID.
+	EnvId string `json:"env_id" required:"true"`
+	// Group ID.
+	GroupId string `json:"group_id" required:"true"`
+}
+
+type CreateVariableOptsBuilder interface {
+	ToCreateVariableOptsMap() (map[string]interface{}, error)
+}
+
+func (opts CreateVariableOpts) ToCreateVariableOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// CreateVariable is a method by which to create function that create a new environment variable.
+func CreateVariable(client *golangsdk.ServiceClient, instanceId string,
+	opts CreateVariableOptsBuilder) (r VariableCreateResult) {
+	reqBody, err := opts.ToCreateVariableOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId, "env-variables"), reqBody, &r.Body, nil)
+	return
+}
+
+// GetVariable is a method to obtain the specified environment variable according to the instance id and variable id.
+func GetVariable(client *golangsdk.ServiceClient, instanceId, varId string) (r VariableGetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, "env-variables", varId), &r.Body, nil)
+	return
+}
+
+// ListVariablesOpts allows to filter list data using given parameters.
+type ListVariablesOpts struct {
+	// API group ID.
+	GroupId string `q:"group_id"`
+	// Environment ID.
+	EnvId string `q:"env_id"`
+	// Variable name.
+	Name string `q:"variable_name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+	// Parameter name for exact matching. Only API variable names are supported.
+	PreciseSearch string `q:"precise_search"`
+}
+
+type ListVariablesOptsBuilder interface {
+	ToListVariablesQuery() (string, error)
+}
+
+func (opts ListVariablesOpts) ToListVariablesQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// ListVariables is a method to obtain an array of one or more variables according to the query parameters.
+func ListVariables(client *golangsdk.ServiceClient, instanceId string, opts ListVariablesOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId, "env-variables")
+	if opts != nil {
+		query, err := opts.ToListVariablesQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VariablePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// DeleteVariable is a method to delete an existing variable.
+func DeleteVariable(client *golangsdk.ServiceClient, instanceId, varId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, "env-variables", varId), nil)
 	return
 }

--- a/openstack/apigw/v2/environments/results.go
+++ b/openstack/apigw/v2/environments/results.go
@@ -47,7 +47,51 @@ func ExtractEnvironments(r pagination.Page) ([]Environment, error) {
 	return s, err
 }
 
-// DeleteResult represents a result of the Delete method.
+// DeleteResult represents a result of the Delete and DeleteVariable method.
 type DeleteResult struct {
 	golangsdk.ErrResult
+}
+
+type VariableResult struct {
+	golangsdk.Result
+}
+
+// VariableCreateResult represents a result of the CreateVariable method.
+type VariableCreateResult struct {
+	VariableResult
+}
+
+// VariableGetResult represents a result of the GetVariable operation.
+type VariableGetResult struct {
+	VariableResult
+}
+
+type Variable struct {
+	// Environment variable ID.
+	Id string `json:"id"`
+	// Variable name.
+	Name string `json:"variable_name"`
+	// Variable value.
+	Value string `json:"variable_value"`
+	// API group ID.
+	GroupId string `json:"group_id"`
+	// Environment ID.
+	EnvId string `json:"env_id"`
+}
+
+func (r VariableResult) Extract() (*Variable, error) {
+	var s Variable
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// VariablePage represents the response pages of the List operation.
+type VariablePage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractVariables(r pagination.Page) ([]Variable, error) {
+	var s []Variable
+	err := r.(VariablePage).Result.ExtractIntoSlicePtr(&s, "variables")
+	return s, err
 }

--- a/openstack/apigw/v2/environments/testing/fixtures.go
+++ b/openstack/apigw/v2/environments/testing/fixtures.go
@@ -41,8 +41,29 @@ const (
 	"id": "3585fce96a5d44f8b445121b9440274a",
 	"name": "terraform_test_update",
 	"remark": "Updated by script"
-}
-`
+}`
+
+	expectedCreateVariableResponse = `
+{
+	"env_id": "3585fce96a5d44f8b445121b9440274a",
+	"group_id": "bd7c9608c05e4e93a6b44e47f19b6bed",
+	"id": "2dc48632332f4157804175175e71e3e8",
+	"variable_name": "Path",
+	"variable_value": "/stage/test"
+}`
+
+	expectedListVariablesResponse = `
+{
+	"variables": [
+		{
+			"env_id": "3585fce96a5d44f8b445121b9440274a",
+			"group_id": "bd7c9608c05e4e93a6b44e47f19b6bed",
+			"id": "2dc48632332f4157804175175e71e3e8",
+			"variable_name": "Path",
+			"variable_value": "/stage/test"
+		}
+	]
+}`
 )
 
 var (
@@ -84,26 +105,53 @@ var (
 			Description: "Updated by script",
 		},
 	}
+
+	variableCreateOpts = &environments.CreateVariableOpts{
+		EnvId:   "3585fce96a5d44f8b445121b9440274a",
+		GroupId: "bd7c9608c05e4e93a6b44e47f19b6bed",
+		Name:    "Path",
+		Value:   "/stage/test",
+	}
+
+	expectedCreateVariableResponseData = &environments.Variable{
+		EnvId:   "3585fce96a5d44f8b445121b9440274a",
+		GroupId: "bd7c9608c05e4e93a6b44e47f19b6bed",
+		Name:    "Path",
+		Value:   "/stage/test",
+		Id:      "2dc48632332f4157804175175e71e3e8",
+	}
+
+	expectedListVariableResponseData = []environments.Variable{
+		{
+			EnvId:   "3585fce96a5d44f8b445121b9440274a",
+			GroupId: "bd7c9608c05e4e93a6b44e47f19b6bed",
+			Name:    "Path",
+			Value:   "/stage/test",
+			Id:      "2dc48632332f4157804175175e71e3e8",
+		},
+	}
 )
 
 func handleV2EnvironmentCreate(t *testing.T) {
-	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/envs", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "POST")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusAccepted)
-		_, _ = fmt.Fprint(w, expectedCreateResponse)
-	})
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/envs",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = fmt.Fprint(w, expectedCreateResponse)
+		})
 }
 
 func handleV2EnvironmentList(t *testing.T) {
-	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/envs", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "GET")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprint(w, expectedListResponse)
-	})
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/envs",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedListResponse)
+		})
 }
 
 func handleV2EnvironmentUpdate(t *testing.T) {
@@ -125,4 +173,47 @@ func handleV2EnvironmentDelete(t *testing.T) {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNoContent)
 		})
+}
+
+func handleV2EnvironmentVariableCreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/env-variables",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedCreateVariableResponse)
+		})
+}
+
+func handleV2EnvironmentVariableGet(t *testing.T) {
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/env-variables"+
+		"/2dc48632332f4157804175175e71e3e8", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedCreateVariableResponse)
+	})
+}
+
+func handleV2EnvironmentVariableList(t *testing.T) {
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/env-variables",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedListVariablesResponse)
+		})
+}
+
+func handleV2EnvironmentVariableDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/cc4ea721cc6747f7969e06bd21121c52/env-variables"+
+		"/2dc48632332f4157804175175e71e3e8", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
 }

--- a/openstack/apigw/v2/environments/testing/requests_test.go
+++ b/openstack/apigw/v2/environments/testing/requests_test.go
@@ -13,7 +13,8 @@ func TestCreateV2Environment(t *testing.T) {
 	defer th.TeardownHTTP()
 	handleV2EnvironmentCreate(t)
 
-	actual, err := environments.Create(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52", createOpts).Extract()
+	actual, err := environments.Create(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52",
+		createOpts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
 }
@@ -23,7 +24,8 @@ func TestListV2Environment(t *testing.T) {
 	defer th.TeardownHTTP()
 	handleV2EnvironmentList(t)
 
-	pages, err := environments.List(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52", environments.ListOpts{}).AllPages()
+	pages, err := environments.List(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52",
+		environments.ListOpts{}).AllPages()
 	th.AssertNoErr(t, err)
 	actual, err := environments.ExtractEnvironments(pages)
 	th.AssertNoErr(t, err)
@@ -48,5 +50,50 @@ func TestDeleteV2Environment(t *testing.T) {
 
 	err := environments.Delete(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52",
 		"3585fce96a5d44f8b445121b9440274a").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestCreateV2EnvironmentVariable(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2EnvironmentVariableCreate(t)
+
+	actual, err := environments.CreateVariable(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52",
+		variableCreateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateVariableResponseData, actual)
+}
+
+func TestGetV2EnvironmentVariable(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2EnvironmentVariableGet(t)
+
+	actual, err := environments.GetVariable(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52",
+		"2dc48632332f4157804175175e71e3e8").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateVariableResponseData, actual)
+}
+
+func TestListV2EnvironmentVariable(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2EnvironmentVariableList(t)
+
+	pages, err := environments.ListVariables(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52",
+		environments.ListVariablesOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := environments.ExtractVariables(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListVariableResponseData, actual)
+}
+
+func TestDeleteV2EnvironmentVariable(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2EnvironmentVariableDelete(t)
+
+	err := environments.DeleteVariable(client.ServiceClient(), "cc4ea721cc6747f7969e06bd21121c52",
+		"2dc48632332f4157804175175e71e3e8").ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/apigw/v2/environments/urls.go
+++ b/openstack/apigw/v2/environments/urls.go
@@ -4,10 +4,10 @@ import "github.com/huaweicloud/golangsdk"
 
 const rootPath = "instances"
 
-func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
-	return c.ServiceURL(rootPath, instanceId, "envs")
+func rootURL(c *golangsdk.ServiceClient, instanceId, path string) string {
+	return c.ServiceURL(rootPath, instanceId, path)
 }
 
-func resourceURL(c *golangsdk.ServiceClient, instanceId, envId string) string {
-	return c.ServiceURL(rootPath, instanceId, "envs", envId)
+func resourceURL(c *golangsdk.ServiceClient, instanceId, path, id string) string {
+	return c.ServiceURL(rootPath, instanceId, path, id)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- In order to support APIG service through terraform, HuaweiCloud sdk needs to be added.
- The APIG contains:
  - Dedicated instance
  - Application
  - Group
  - Responses
  - Environment
    - **Environment variables**
  - API
  - Domains
  - ACL
  - Request throttling policy
  - ...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. add some methods to apig environments sdk:
  - CreateVariable
  - GetVariable
  - ListVariables
  - DeleteVariable
2. add test for each variable methods.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2Environment
--- PASS: TestCreateV2Environment (0.00s)
=== RUN   TestListV2Environment
--- PASS: TestListV2Environment (0.00s)
=== RUN   TestUpdateV2Environment
--- PASS: TestUpdateV2Environment (0.00s)
=== RUN   TestDeleteV2Environment
--- PASS: TestDeleteV2Environment (0.00s)
=== RUN   TestCreateV2EnvironmentVariable
--- PASS: TestCreateV2EnvironmentVariable (0.00s)
=== RUN   TestGetV2EnvironmentVariable
--- PASS: TestGetV2EnvironmentVariable (0.00s)
=== RUN   TestListV2EnvironmentVariable
--- PASS: TestListV2EnvironmentVariable (0.00s)
=== RUN   TestDeleteV2EnvironmentVariable
--- PASS: TestDeleteV2EnvironmentVariable (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments/testing        0.015s
```