### PR TITLE
Core: reuse HTTP connection when possible

### DIFF
--- a/openstack/imageservice/v2/imagedata/doc.go
+++ b/openstack/imageservice/v2/imagedata/doc.go
@@ -40,6 +40,9 @@ Example to Download Image Data
 		panic(err)
 	}
 
+	// close the reader, when reading has finished
+	defer image.Close()
+
 	imageData, err := ioutil.ReadAll(image)
 	if err != nil {
 		panic(err)

--- a/openstack/imageservice/v2/imagedata/requests.go
+++ b/openstack/imageservice/v2/imagedata/requests.go
@@ -30,7 +30,9 @@ func Stage(client *golangsdk.ServiceClient, id string, data io.Reader) (r StageR
 // Download retrieves an image.
 func Download(client *golangsdk.ServiceClient, id string) (r DownloadResult) {
 	var resp *http.Response
-	resp, r.Err = client.Get(downloadURL(client, id), nil, nil)
+	resp, r.Err = client.Get(downloadURL(client, id), nil, &golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	})
 	if resp != nil {
 		r.Body = resp.Body
 		r.Header = resp.Header

--- a/openstack/imageservice/v2/imagedata/results.go
+++ b/openstack/imageservice/v2/imagedata/results.go
@@ -1,7 +1,6 @@
 package imagedata
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/huaweicloud/golangsdk"
@@ -23,12 +22,13 @@ type StageResult struct {
 // method to gain access to the image data.
 type DownloadResult struct {
 	golangsdk.Result
+	Body io.ReadCloser
 }
 
 // Extract builds images model from io.Reader
-func (r DownloadResult) Extract() (io.Reader, error) {
-	if r, ok := r.Body.(io.Reader); ok {
-		return r, nil
+func (r DownloadResult) Extract() (io.ReadCloser, error) {
+	if r.Err != nil {
+		return nil, r.Err
 	}
-	return nil, fmt.Errorf("Expected io.Reader but got: %T(%#v)", r.Body, r.Body)
+	return r.Body, nil
 }

--- a/openstack/imageservice/v2/imagedata/testing/requests_test.go
+++ b/openstack/imageservice/v2/imagedata/testing/requests_test.go
@@ -94,6 +94,8 @@ func TestDownload(t *testing.T) {
 	rdr, err := imagedata.Download(fakeclient.ServiceClient(), "da3b75d9-3f4a-40e7-8a2c-bfab23927dea").Extract()
 	th.AssertNoErr(t, err)
 
+	defer rdr.Close()
+
 	bs, err := ioutil.ReadAll(rdr)
 	th.AssertNoErr(t, err)
 

--- a/openstack/objectstorage/v1/objects/doc.go
+++ b/openstack/objectstorage/v1/objects/doc.go
@@ -98,6 +98,10 @@ Example to Download an Object's Data
 	containerName := "my_container"
 
 	object := objects.Download(objectStorageClient, containerName, objectName, nil)
+	if object.Err != nil {
+		panic(object.Err)
+	}
+	// if "ExtractContent" method is not called, the HTTP connection will remain consumed
 	content, err := object.ExtractContent()
 	if err != nil {
 		panic(err)

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -126,8 +126,9 @@ func Download(c *golangsdk.ServiceClient, containerName, objectName string, opts
 	}
 
 	resp, err := c.Get(url, nil, &golangsdk.RequestOpts{
-		MoreHeaders: h,
-		OkCodes:     []int{200, 206, 304},
+		MoreHeaders:      h,
+		OkCodes:          []int{200, 206, 304},
+		KeepResponseBody: true,
 	})
 	if resp != nil {
 		r.Header = resp.Header

--- a/openstack/objectstorage/v1/objects/results.go
+++ b/openstack/objectstorage/v1/objects/results.go
@@ -216,7 +216,6 @@ func (r *DownloadResult) ExtractContent() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.Body.Close()
 	return body, nil
 }
 

--- a/pagination/http.go
+++ b/pagination/http.go
@@ -54,7 +54,8 @@ func PageResultFromParsed(resp *http.Response, body interface{}) PageResult {
 // Request performs an HTTP request and extracts the http.Response from the result.
 func Request(client *golangsdk.ServiceClient, headers map[string]string, url string) (*http.Response, error) {
 	return client.Get(url, nil, &golangsdk.RequestOpts{
-		MoreHeaders: headers,
-		OkCodes:     []int{200, 204, 300},
+		MoreHeaders:      headers,
+		OkCodes:          []int{200, 204, 300},
+		KeepResponseBody: true,
 	})
 }

--- a/provider_client.go
+++ b/provider_client.go
@@ -3,6 +3,7 @@ package golangsdk
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -158,6 +159,9 @@ type RequestOpts struct {
 	// ErrorContext specifies the resource error type to return if an error is encountered.
 	// This lets resources override default error messages based on the response status code.
 	ErrorContext error
+	// KeepResponseBody specifies whether to keep the HTTP response body. Usually used, when the HTTP
+	// response body is considered for further use. Valid when JSONResponse is nil.
+	KeepResponseBody bool
 }
 
 var applicationJSON = "application/json"
@@ -190,6 +194,11 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 
 		body = bytes.NewReader(rendered)
 		contentType = &applicationJSON
+	}
+
+	// Return an error, when "KeepResponseBody" is true and "JSONResponse" is not nil
+	if options.KeepResponseBody && options.JSONResponse != nil {
+		return nil, errors.New("cannot use KeepResponseBody when JSONResponse is not nil")
 	}
 
 	if options.RawBody != nil {
@@ -226,9 +235,6 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	for k, v := range client.AuthenticatedHeaders() {
 		req.Header.Set(k, v)
 	}
-
-	// Set connection parameter to close the connection immediately when we've got the response
-	req.Close = true
 
 	prereqtok := req.Header.Get("X-Auth-Token")
 
@@ -380,7 +386,22 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	// Parse the response body as JSON, if requested to do so.
 	if options.JSONResponse != nil {
 		defer resp.Body.Close()
+		// Don't decode JSON when there is no content
+		if resp.StatusCode == http.StatusNoContent {
+			// read till EOF, otherwise the connection will be closed and cannot be reused
+			_, err = io.Copy(ioutil.Discard, resp.Body)
+			return resp, err
+		}
 		if err := json.NewDecoder(resp.Body).Decode(options.JSONResponse); err != nil {
+			return nil, err
+		}
+	}
+
+	// Close unused body to allow the HTTP connection to be reused
+	if !options.KeepResponseBody && options.JSONResponse == nil {
+		defer resp.Body.Close()
+		// read till EOF, otherwise the connection will be closed and cannot be reused
+		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
backporting: gophercloud/gophercloud#1952

```
$ go test -v -run=TestRequestConnectionReuse
=== RUN   TestRequestConnectionReuse
--- PASS: TestRequestConnectionReuse (1.74s)
PASS
ok      github.com/huaweicloud/golangsdk/testing        1.745s

$ go test -v -run=TestRequestConnectionClose
=== RUN   TestRequestConnectionClose
--- PASS: TestRequestConnectionClose (0.01s)
PASS
ok      github.com/huaweicloud/golangsdk/testing        0.014s

$ go test -v -run=TestConcurrentReauth
=== RUN   TestConcurrentReauth
--- PASS: TestConcurrentReauth (1.02s)
PASS
ok      github.com/huaweicloud/golangsdk/testing        1.024s
```

