### PR TITLE
Fix the golangsdk test error

### DIFF
--- a/openstack/apigw/v2/instances/testing/fixtures.go
+++ b/openstack/apigw/v2/instances/testing/fixtures.go
@@ -93,13 +93,6 @@ const (
 		}
 	]
 }`
-	expectedUpdateIngressResponse = `
-{
-	"eip_address": "94.74.115.227",
-	"eip_id": "706673d2-e36b-4577-87bc-e6d6e71812f7",
-	"eip_status": "ACTIVE"
-}
-`
 )
 
 var (
@@ -150,12 +143,6 @@ var (
 
 	updateIngressOpts = instances.IngressAccessOpts{
 		EipId: "706673d2-e36b-4577-87bc-e6d6e71812f7",
-	}
-
-	expectedUpdateIngressResponseData = &instances.Ingress{
-		ID:          "706673d2-e36b-4577-87bc-e6d6e71812f7",
-		Ipv4Address: "94.74.115.227",
-		Status:      "ACTIVE",
 	}
 
 	expectedGetResponseData = &instances.Instance{
@@ -260,21 +247,11 @@ func handleV2InstanceEgressDisable(t *testing.T) {
 	})
 }
 
-func handleV2InstanceIngressUpdate(t *testing.T) {
-	th.Mux.HandleFunc("/instances/e6a5871bfb5b47d19c5874790f639ef8/eip", func(w http.ResponseWriter, r *http.Request) {
-		th.TestMethod(t, r, "PUT")
-		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprint(w, expectedUpdateIngressResponse)
-	})
-}
-
 func handleV2InstanceIngressDisable(t *testing.T) {
 	th.Mux.HandleFunc("/instances/e6a5871bfb5b47d19c5874790f639ef8/eip", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/openstack/apigw/v2/instances/testing/requests_test.go
+++ b/openstack/apigw/v2/instances/testing/requests_test.go
@@ -68,17 +68,6 @@ func TestDisableEgressV2Instance(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
-func TestUpdateIngressV2Instance(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
-	handleV2InstanceIngressUpdate(t)
-
-	actual, err := instances.UpdateIngressAccess(client.ServiceClient(), "e6a5871bfb5b47d19c5874790f639ef8",
-		updateIngressOpts).Extract()
-	th.AssertNoErr(t, err)
-	th.AssertDeepEquals(t, expectedUpdateIngressResponseData, actual)
-}
-
 func TestDisableIngressV2Instance(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The update method of instance ingress has been removed,  but the test function is not removed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. remove ingress update method.
2. fix the wrong status code of ingress unbind method.
```

## Acceptance Steps Performed

```
go test -v -run Test=== RUN   TestCreateV2Instance
--- PASS: TestCreateV2Instance (0.00s)
=== RUN   TestGetV2Instance
--- PASS: TestGetV2Instance (0.00s)
=== RUN   TestListV2Instance
--- PASS: TestListV2Instance (0.00s)
=== RUN   TestUpdateV2Instance
--- PASS: TestUpdateV2Instance (0.00s)
=== RUN   TestDeleteV2Instance
--- PASS: TestDeleteV2Instance (0.00s)
=== RUN   TestDisableEgressV2Instance
--- PASS: TestDisableEgressV2Instance (0.00s)
=== RUN   TestDisableIngressV2Instance
--- PASS: TestDisableIngressV2Instance (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/instances/testing   0.017s
```
