### PR TITLE
Core: introduce the retry backoff

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -109,16 +109,17 @@ An example retry backoff function, which respects the 429 HTTP response code and
 		// Parse delay seconds or HTTP date
 		if v, err := strconv.ParseUint(retryAfter, 10, 32); err == nil {
 			sleep = time.Duration(v) * time.Second
-		} else if v, err := time.Parse(http.TimeFormat, retryAfter); err != nil {
-			return e
+		} else if v, err := time.Parse(http.TimeFormat, retryAfter); err == nil {
+			sleep = time.Until(v)
 		} else {
-			sleep = v.UTC().Sub(time.Now().UTC())
+			return e
 		}
 
 		if ctx != nil {
 			select {
 			case <-time.After(sleep):
 			case <-ctx.Done():
+				return e
 			}
 		} else {
 			time.Sleep(sleep)

--- a/doc.go
+++ b/doc.go
@@ -89,5 +89,43 @@ intermediary processing on each page, you can use the AllPages method:
 This top-level package contains utility functions and data types that are used
 throughout the provider and service packages. Of particular note for end users
 are the AuthOptions and EndpointOpts structs.
+
+An example retry backoff function, which respects the 429 HTTP response code and a "Retry-After" header:
+
+	endpoint := "http://localhost:5000"
+	provider, err := openstack.NewClient(endpoint)
+	if err != nil {
+		panic(err)
+	}
+	provider.MaxBackoffRetries = 3 // max three retries
+	provider.RetryBackoffFunc = func(ctx context.Context, respErr *ErrUnexpectedResponseCode, e error, retries uint) error {
+		retryAfter := respErr.ResponseHeader.Get("Retry-After")
+		if retryAfter == "" {
+			return e
+		}
+
+		var sleep time.Duration
+
+		// Parse delay seconds or HTTP date
+		if v, err := strconv.ParseUint(retryAfter, 10, 32); err == nil {
+			sleep = time.Duration(v) * time.Second
+		} else if v, err := time.Parse(http.TimeFormat, retryAfter); err != nil {
+			return e
+		} else {
+			sleep = v.UTC().Sub(time.Now().UTC())
+		}
+
+		if ctx != nil {
+			select {
+			case <-time.After(sleep):
+			case <-ctx.Done():
+			}
+		} else {
+			time.Sleep(sleep)
+		}
+
+		return nil
+	}
+
 */
 package golangsdk

--- a/errors.go
+++ b/errors.go
@@ -138,8 +138,11 @@ func (e ErrDefault408) Error() string {
 	return "The server timed out waiting for the request"
 }
 func (e ErrDefault429) Error() string {
-	return "Too many requests have been sent in a given amount of time. Pause" +
-		" requests, wait up to one minute, and try again."
+	e.DefaultErrString = fmt.Sprintf(
+		"Too many requests: [%s %s], error message: %s",
+		e.Method, e.URL, e.Body,
+	)
+	return e.choseErrString()
 }
 func (e ErrDefault500) Error() string {
 	return "Internal Server Error"

--- a/provider_client.go
+++ b/provider_client.go
@@ -15,7 +15,7 @@ import (
 // DefaultUserAgent is the default User-Agent string set in the request header.
 const (
 	DefaultUserAgent         = "golangsdk/2.0.0"
-	DefaultMaxBackoffRetries = 60
+	DefaultMaxBackoffRetries = 5
 )
 
 // UserAgent represents a User-Agent header.

--- a/provider_client.go
+++ b/provider_client.go
@@ -431,13 +431,12 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 			if f := client.RetryBackoffFunc; f != nil && state.retries < maxTries {
 				var e error
 
-				state.retries = state.retries + 1
 				e = f(client.Context, &respErr, err, state.retries)
-
 				if e != nil {
 					return resp, e
 				}
 
+				state.retries = state.retries + 1
 				return client.doRequest(method, url, options, state)
 			}
 		case http.StatusInternalServerError:

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -269,6 +269,7 @@ func TestRequestRetry(t *testing.T) {
 	if err == nil {
 		t.Fatal("expecting error, got nil")
 	}
+	t.Logf("error message: %s", err)
 	th.AssertEquals(t, retryCounter, p.MaxBackoffRetries)
 }
 

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -214,4 +215,188 @@ func TestRequestConnectionClose(t *testing.T) {
 	}
 
 	th.AssertEquals(t, int64(iter), connections)
+}
+
+type testRetryFunc func(context.Context, *golangsdk.ErrUnexpectedResponseCode, error, uint) error
+
+func retryTest(retryCounter *uint, t *testing.T) testRetryFunc {
+	return func(ctx context.Context, respErr *golangsdk.ErrUnexpectedResponseCode, e error, retries uint) error {
+		retryAfter := respErr.ResponseHeader.Get("Retry-After")
+		if retryAfter == "" {
+			return e
+		}
+
+		var sleep time.Duration
+
+		// Parse delay seconds or HTTP date
+		if v, err := strconv.ParseUint(retryAfter, 10, 32); err == nil {
+			sleep = time.Duration(v) * time.Second
+		} else if v, err := time.Parse(http.TimeFormat, retryAfter); err != nil {
+			return e
+		} else {
+			sleep = v.UTC().Sub(time.Now().UTC())
+		}
+
+		if ctx != nil {
+			t.Logf("Context sleeping for %d milliseconds", sleep.Milliseconds())
+			select {
+			case <-time.After(sleep):
+				t.Log("sleep is over")
+			case <-ctx.Done():
+				t.Log("context exceeded")
+				return e
+			}
+		} else {
+			t.Logf("Sleeping for %d milliseconds", sleep.Milliseconds())
+			time.Sleep(sleep)
+			t.Log("sleep is over")
+		}
+
+		*retryCounter = *retryCounter + 1
+
+		return nil
+	}
+}
+
+func TestRequestRetry(t *testing.T) {
+	var retryCounter uint
+
+	p := &golangsdk.ProviderClient{}
+	p.UseTokenLock()
+	p.SetToken(client.TokenID)
+	p.MaxBackoffRetries = 3
+
+	p.RetryBackoffFunc = retryTest(&retryCounter, t)
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "1")
+
+		//always reply 429
+		http.Error(w, "retry later", http.StatusTooManyRequests)
+	})
+
+	_, err := p.Request("GET", th.Endpoint()+"/route", &golangsdk.RequestOpts{})
+	if err == nil {
+		t.Fatal("expecting error, got nil")
+	}
+	th.AssertEquals(t, retryCounter, p.MaxBackoffRetries)
+}
+
+func TestRequestRetryHTTPDate(t *testing.T) {
+	var retryCounter uint
+
+	p := &golangsdk.ProviderClient{}
+	p.UseTokenLock()
+	p.SetToken(client.TokenID)
+	p.MaxBackoffRetries = 3
+
+	p.RetryBackoffFunc = retryTest(&retryCounter, t)
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", time.Now().Add(1*time.Second).UTC().Format(http.TimeFormat))
+
+		//always reply 429
+		http.Error(w, "retry later", http.StatusTooManyRequests)
+	})
+
+	_, err := p.Request("GET", th.Endpoint()+"/route", &golangsdk.RequestOpts{})
+	if err == nil {
+		t.Fatal("expecting error, got nil")
+	}
+	th.AssertEquals(t, retryCounter, p.MaxBackoffRetries)
+}
+
+func TestRequestRetryError(t *testing.T) {
+	var retryCounter uint
+
+	p := &golangsdk.ProviderClient{}
+	p.UseTokenLock()
+	p.SetToken(client.TokenID)
+	p.MaxBackoffRetries = 3
+
+	p.RetryBackoffFunc = retryTest(&retryCounter, t)
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "foo bar")
+
+		//always reply 429
+		http.Error(w, "retry later", http.StatusTooManyRequests)
+	})
+
+	_, err := p.Request("GET", th.Endpoint()+"/route", &golangsdk.RequestOpts{})
+	if err == nil {
+		t.Fatal("expecting error, got nil")
+	}
+	th.AssertEquals(t, retryCounter, uint(0))
+}
+
+func TestRequestRetrySuccess(t *testing.T) {
+	var retryCounter uint
+
+	p := &golangsdk.ProviderClient{}
+	p.UseTokenLock()
+	p.SetToken(client.TokenID)
+	p.MaxBackoffRetries = 3
+
+	p.RetryBackoffFunc = retryTest(&retryCounter, t)
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+		//always reply 200
+		http.Error(w, "retry later", http.StatusOK)
+	})
+
+	_, err := p.Request("GET", th.Endpoint()+"/route", &golangsdk.RequestOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	th.AssertEquals(t, retryCounter, uint(0))
+}
+
+func TestRequestRetryContext(t *testing.T) {
+	var retryCounter uint
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		sleep := 2.5 * 1000 * time.Millisecond
+		time.Sleep(sleep)
+		cancel()
+	}()
+
+	p := &golangsdk.ProviderClient{
+		Context: ctx,
+	}
+	p.UseTokenLock()
+	p.SetToken(client.TokenID)
+	p.MaxBackoffRetries = 3
+
+	p.RetryBackoffFunc = retryTest(&retryCounter, t)
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "1")
+
+		//always reply 429
+		http.Error(w, "retry later", http.StatusTooManyRequests)
+	})
+
+	_, err := p.Request("GET", th.Endpoint()+"/route", &golangsdk.RequestOpts{})
+	if err == nil {
+		t.Fatal("expecting error, got nil")
+	}
+	t.Logf("retryCounter: %d, p.MaxBackoffRetries: %d", retryCounter, p.MaxBackoffRetries-1)
+	th.AssertEquals(t, retryCounter, p.MaxBackoffRetries-1)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
retry backoff when we got 429 error code.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
$ cd testing/

$ go test -v -run=TestRequestRetry
=== RUN   TestRequestRetry
    provider_client_test.go:239: Sleeping for 1 seconds, retry number 0
    provider_client_test.go:241: sleep is over
    provider_client_test.go:239: Sleeping for 2 seconds, retry number 1
    provider_client_test.go:241: sleep is over
    provider_client_test.go:239: Sleeping for 4 seconds, retry number 2
    provider_client_test.go:241: sleep is over
    provider_client_test.go:272: error message: Too many requests: [GET http://127.0.0.1:50834//route], error message: retry later
--- PASS: TestRequestRetry (7.01s)
=== RUN   TestRequestRetrySuccess
--- PASS: TestRequestRetrySuccess (0.00s)
=== RUN   TestRequestRetryContext
    provider_client_test.go:230: Context sleeping for 1 seconds, retry number 0
    provider_client_test.go:233: sleep is over
    provider_client_test.go:230: Context sleeping for 2 seconds, retry number 1
    provider_client_test.go:233: sleep is over
    provider_client_test.go:230: Context sleeping for 4 seconds, retry number 2
    provider_client_test.go:235: context canceled
    provider_client_test.go:332: retryCounter: 2, p.MaxBackoffRetries: 3
--- PASS: TestRequestRetryContext (5.00s)
PASS
ok      github.com/huaweicloud/golangsdk/testing        12.019s
```

