### PR TITLE
New vpc channel sdk and test of APIG service

### DIFF
--- a/openstack/apigw/v2/channels/requests.go
+++ b/openstack/apigw/v2/channels/requests.go
@@ -1,0 +1,266 @@
+package channels
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type ChannelOpts struct {
+	// Backend server list. Only one backend server is included if the VPC channel type is set to 1.
+	Members []MemberInfo `json:"members" required:"true"`
+	// VPC channel name.
+	// A VPC channel name can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name" required:"true"`
+	// VPC channel type.
+	//     1: private network ELB channel (to be deprecated)
+	//     2: fast channel with the load balancing function
+	Type int `json:"type" required:"true"`
+	// Health check details.
+	VpcHealthConfig VpcHealthConfig `json:"vpc_health_config" required:"true"`
+	// Distribution algorithm.
+	// The valid values are as following:
+	//     1: WRR (default)
+	//     2: WLC
+	//     3: SH
+	//     4: URI hashing
+	// This parameter is mandatory if the VPC channel type is set to 2.
+	BalanceStrategy int `json:"balance_strategy,omitempty"`
+	// Member type of the VPC channel.
+	// The valid values are as following:
+	//     ip
+	//     ecs (default)
+	// This parameter is required if the VPC channel type is set to 2.
+	MemberType string `json:"member_type,omitempty"`
+	// Host port of the VPC channel.
+	// This parameter is valid only when the VPC channel type is set to 2. The value range is 1–65535.
+	// This parameter is required if the VPC channel type is set to 2.
+	Port int `json:"port,omitempty"`
+}
+
+type MemberInfo struct {
+	// Backend server ID.
+	// This parameter is valid when the member type is instance.
+	// The value can contain 1 to 64 characters, including letters, digits, hyphens (-), and underscores (_).
+	EcsId string `json:"ecs_id,omitempty"`
+	// Backend server name, which contains of 1 to 64 characters, including letters, digits, periods (.), hyphens (-)
+	// and underscores (_).
+	// This parameter is valid when the member type is instance.
+	EcsName string `json:"ecs_name,omitempty"`
+	// Backend server address.
+	// This parameter is valid when the member type is IP address.
+	Host string `json:"host,omitempty"`
+	// Backend server weight.
+	// The higher the weight is, the more requests a cloud server will receive.
+	// The weight is only available for the WRR and WLC algorithms.
+	// It is valid only when the VPC channel type is set to 2.
+	// The valid value is range from 0 to 100.
+	Weight int `json:"weight,omitempty"`
+}
+
+type VpcHealthConfig struct {
+	// Protocol for performing health checks on backend servers in the VPC channel.
+	// The valid values are as following:
+	//     TCP
+	//     HTTP
+	//     HTTPS
+	Protocol string `json:"protocol" required:"true"`
+	// Healthy threshold, which refers to the number of consecutive successful checks required for a backend server to
+	// be considered healthy.
+	// The valid value is range from 2 to 10.
+	ThresholdNormal int `json:"threshold_normal" required:"true"`
+	// Unhealthy threshold, which refers to the number of consecutive failed checks required for a backend server to be
+	// considered unhealthy.
+	// The valid value is range from 2 to 10.
+	ThresholdAbnormal int `json:"threshold_abnormal" required:"true"`
+	// Interval between consecutive checks, in second. The value must be greater than the value of timeout.
+	// The valid value is range from 5 to 300.
+	TimeInterval int `json:"time_interval" required:"true"`
+	// Timeout for determining whether a health check fails, in second.
+	// The value must be less than the value of time_interval.
+	// The valid value is range from 2 to 30.
+	Timeout int `json:"timeout" required:"true"`
+	// Indicates whether to enable two-way authentication.
+	// If this function is enabled, the certificate specified in the backend_client_certificate configuration item of
+	// the gateway is used. Default to false.
+	EnableClientSsl bool `json:"enable_client_ssl,omitempty"`
+	// Response codes for determining a successful HTTP response.
+	// The value can be any integer within 100–599 in one of the following formats:
+	//     Value, for example, 200.
+	//     Multiple values, for example, 200,201,202.
+	//     Range, for example, 200-299.
+	//     Multiple values and ranges, for example, 201,202,210-299.
+	// This parameter is required if protocol is set to http.
+	HttpCodes string `json:"http_code,omitempty"`
+	// Request method for health checks.
+	// The valid values are as following:
+	//     GET (default)
+	//     HEAD
+	Method string `json:"method,omitempty"`
+	// Destination path for health checks. This parameter is required if protocol is set to http.
+	Path string `json:"path,omitempty"`
+	// Destination port for health checks. By default, the host port of the VPC channel is used.
+	// The valid value is range from 1 to 65535.
+	Port int `json:"port,omitempty"`
+}
+
+type ChannelOptsBuilder interface {
+	ToInstanceCreateMap() (map[string]interface{}, error)
+}
+
+func (opts ChannelOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a APIG vpc channel.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts ChannelOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToInstanceCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+// Create is a method by which to create function that create a APIG vpc channel.
+func Update(client *golangsdk.ServiceClient, instanceId, chanId string, opts ChannelOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToInstanceCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, chanId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Create is a method by which to create function that create a APIG vpc channel.
+func Get(client *golangsdk.ServiceClient, instanceId, chanId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, chanId), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// VPC channel ID.
+	Id string `q:"id"`
+	// VPC channel name.
+	Name string `q:"name"`
+	// VPC channel type.
+	VpcType int `q:"vpc_type"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page.
+	Limit int `q:"limit"`
+	// Parameter name (name) for exact matching.
+	PreciseSearch string `q:"precise_search"`
+}
+
+type ListOptsBuilder interface {
+	ToChannelListQuery() (string, error)
+}
+
+func (opts ListOpts) ToChannelListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more vpc channels by query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToChannelListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ChannelPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing vpc channel.
+func Delete(client *golangsdk.ServiceClient, instanceId, chanId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, chanId), nil)
+	return
+}
+
+type BackendAddOpts struct {
+	// Backend server list.
+	Members []MemberInfo `json:"members" required:"true"`
+}
+
+type BackendAddOptsBuilder interface {
+	ToBackendAddMap() (map[string]interface{}, error)
+}
+
+func (opts BackendAddOpts) ToBackendAddMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// AddBackendServices is a method to add a backend instance to vpc channel.
+func AddBackendServices(client *golangsdk.ServiceClient, instanceId, chanId string,
+	opts BackendAddOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToBackendAddMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(membersURL(client, instanceId, chanId), reqBody, &r.Body, nil)
+	return
+}
+
+// BackendListOpts allows to filter list data using given parameters.
+type BackendListOpts struct {
+	// Cloud server name.
+	Name string `q:"name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page.
+	Limit int `q:"limit"`
+}
+
+type BackendListOptsBuilder interface {
+	ToBackendListQuery() (string, error)
+}
+
+func (opts BackendListOpts) ToBackendListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// ListBackendServices is a method to obtain an array of one or more backend services by query parameters.
+func ListBackendServices(client *golangsdk.ServiceClient, instanceId, chanId string,
+	opts BackendListOptsBuilder) pagination.Pager {
+	url := membersURL(client, instanceId, chanId)
+	if opts != nil {
+		query, err := opts.ToBackendListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ChannelPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// RemoveBackendService is a method to remove an existing backend instance form vpc channel.
+func RemoveBackendService(client *golangsdk.ServiceClient, instanceId, chanId, memberId string) (r RemoveResult) {
+	_, r.Err = client.Delete(memberURL(client, instanceId, chanId, memberId), nil)
+	return
+}

--- a/openstack/apigw/v2/channels/requests.go
+++ b/openstack/apigw/v2/channels/requests.go
@@ -43,7 +43,7 @@ type MemberInfo struct {
 	// Backend server ID.
 	// This parameter is valid when the member type is instance.
 	// The value can contain 1 to 64 characters, including letters, digits, hyphens (-), and underscores (_).
-	EcsId string `json:"ecs_id,omitempty"`
+	EcsId string `json:"ecs_id,omitempty" xor:"Host"`
 	// Backend server name, which contains of 1 to 64 characters, including letters, digits, periods (.), hyphens (-)
 	// and underscores (_).
 	// This parameter is valid when the member type is instance.
@@ -113,7 +113,7 @@ func (opts ChannelOpts) ToInstanceCreateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-// Create is a method by which to create function that create a APIG vpc channel.
+// Create is a method by which to create an APIG vpc channel.
 func Create(client *golangsdk.ServiceClient, instanceId string, opts ChannelOptsBuilder) (r CreateResult) {
 	reqBody, err := opts.ToInstanceCreateMap()
 	if err != nil {
@@ -124,7 +124,7 @@ func Create(client *golangsdk.ServiceClient, instanceId string, opts ChannelOpts
 	return
 }
 
-// Create is a method by which to create function that create a APIG vpc channel.
+// Update is a method by which to update an existing APIG vpc channel by request parameters.
 func Update(client *golangsdk.ServiceClient, instanceId, chanId string, opts ChannelOptsBuilder) (r UpdateResult) {
 	reqBody, err := opts.ToInstanceCreateMap()
 	if err != nil {
@@ -137,7 +137,7 @@ func Update(client *golangsdk.ServiceClient, instanceId, chanId string, opts Cha
 	return
 }
 
-// Create is a method by which to create function that create a APIG vpc channel.
+// Get is a method to obtain an existing APIG vpc channel by channel ID.
 func Get(client *golangsdk.ServiceClient, instanceId, chanId string) (r GetResult) {
 	_, r.Err = client.Get(resourceURL(client, instanceId, chanId), &r.Body, nil)
 	return

--- a/openstack/apigw/v2/channels/results.go
+++ b/openstack/apigw/v2/channels/results.go
@@ -1,0 +1,152 @@
+package channels
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// GetResult represents the result of a create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// UdpateResult represents the result of a update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a update operation.
+type GetResult struct {
+	commonResult
+}
+
+type VpcChannel struct {
+	// VPC channel name.
+	// A VPC channel name can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name"`
+	// VPC channel type.
+	// 1: private network ELB channel (to be deprecated)
+	// 2: fast channel with the load balancing function
+	Type int `json:"type"`
+	// Host port of the VPC channel.
+	// This parameter is valid only when the VPC channel type is set to 2.
+	// This parameter is required if the VPC channel type is set to 2.
+	// The value range is 1–65535.
+	Port int `json:"port"`
+	// Distribution algorithm.
+	// 1: WRR (default)
+	// 2: WLC
+	// 3: SH
+	// 4: URI hashing
+	// This parameter is mandatory if the VPC channel type is set to 2.
+	BalanceStrategy int `json:"balance_strategy"`
+	// Member type of the VPC channel.
+	// ip
+	// ecs (default)
+	// This parameter is required if the VPC channel type is set to 2.
+	MemberType string `json:"member_type"`
+	// Time when the VPC channel is created.
+	CreateTime string `json:"create_time"`
+	// VPC channel ID.
+	Id string `json:"id"`
+	// VPC channel status.
+	// 1: normal
+	// 2: abnormal
+	Status int `json:"status"`
+	// ID of a private network ELB channel.
+	// This parameter is valid only when the VPC channel type is set to 1.
+	ElbId string `json:"elb_id"`
+	// Backend server list. Only one backend server is included if the VPC channel type is set to 1.
+	Members []MemberInfo `json:"members"`
+	// Health check details.
+	VpcHealthConfig VpcHealthConfig `json:"vpc_health_config"`
+}
+
+func (r commonResult) Extract() (*VpcChannel, error) {
+	var s VpcChannel
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// The ChannelPage represents the result of a List operation.
+type ChannelPage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractInstances its Extract method to interpret it as a VpcChannel array.
+func ExtractInstances(r pagination.Page) ([]VpcChannel, error) {
+	var s []VpcChannel
+	err := r.(ChannelPage).Result.ExtractIntoSlicePtr(&s, "vpc_channels")
+	return s, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type MemberResult struct {
+	golangsdk.Result
+}
+
+type AddBackendResult struct {
+	MemberResult
+}
+
+type GetBackendResult struct {
+	MemberResult
+}
+
+type Member struct {
+	// VPC channel name.
+	// A VPC channel name can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name"`
+	// VPC channel type.
+	// 1: private network ELB channel (to be deprecated)
+	// 2: fast channel with the load balancing function
+	Type int `json:"type"`
+	// Host port of the VPC channel.
+	// This parameter is valid only when the VPC channel type is set to 2. The value range is 1–65535.
+	// This parameter is required if the VPC channel type is set to 2.
+	Port int `json:"port"`
+	// Distribution algorithm.
+	// 1: WRR (default)
+	// 2: WLC
+	// 3: SH
+	// 4: URI hashing
+	// This parameter is mandatory if the VPC channel type is set to 2.
+	BalanceStrategy int `json:"balance_strategy"`
+	// Member type of the VPC channel.
+	// ip
+	// ecs (default)
+	// This parameter is required if the VPC channel type is set to 2.
+	MemberType string `json:"member_type"`
+	// Time when the VPC channel is created.
+	CreateTime string `json:"create_time"`
+	// VPC channel ID.
+	Id string `json:"id"`
+	// VPC channel status.
+	// 1: normal
+	// 2: abnormal
+	Status int `json:"status"`
+	// ID of a private network ELB channel.
+	// This parameter is valid only when the VPC channel type is set to 1.
+	ElbId string `json:"elb_id"`
+}
+
+func (r MemberResult) Extract() ([]Member, error) {
+	var s []Member
+	err := r.ExtractIntoStructPtr(&s, "members")
+	return s, err
+}
+
+type RemoveResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/apigw/v2/channels/testing/fixtures.go
+++ b/openstack/apigw/v2/channels/testing/fixtures.go
@@ -1,0 +1,254 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/channels"
+
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedCreateResponse = `
+{
+	"balance_strategy": 1,
+	"create_time": "2021-07-05T09:29:38Z",
+	"id": "328d1d563eba4ff084533188b84b9f8d",
+	"member_type": "ecs",
+	"name": "terraform_test",
+	"port": 8080,
+	"status": 1,
+	"type": 2
+}`
+	expectedGetResponse = `
+{
+	"balance_strategy": 1,
+	"create_time": "2021-07-05T09:29:38Z",
+	"id": "328d1d563eba4ff084533188b84b9f8d",
+	"member_type": "ecs",
+	"members": [
+		{
+			"ecs_id": "dfe1f776-dd07-4ec0-912f-47525679d76a",
+			"ecs_name": "terraform_test",
+			"host": "192.168.9.195",
+			"weight": 1
+		}
+	],
+	"name": "terraform_test",
+	"port": 8080,
+	"status": 1,
+	"type": 2,
+	"vpc_health_config": {
+		"http_code": "201,202,203",
+		"method": "GET",
+		"path": "/",
+		"port": 8080,
+		"protocol": "https",
+		"threshold_abnormal": 5,
+		"threshold_normal": 2,
+		"time_interval": 10,
+		"timeout": 5
+	}
+}`
+	expectedListResponse = `
+{
+	"vpc_channels": [
+		{
+			"balance_strategy": 1,
+			"create_time": "2021-07-05T09:29:38Z",
+			"id": "328d1d563eba4ff084533188b84b9f8d",
+			"member_type": "ecs",
+			"members": [
+				{
+					"create_time": "2021-07-05T09:29:38Z",
+					"ecs_id": "dfe1f776-dd07-4ec0-912f-47525679d76a",
+					"ecs_name": "terraform_test",
+					"host": "192.168.9.195",
+					"id": "a4ffcf94477a4e3697deb5700313d861",
+					"status": 1,
+					"vpc_channel_id": "328d1d563eba4ff084533188b84b9f8d",
+					"weight": 1
+				}
+			],
+			"name": "terraform_test",
+			"port": 8080,
+			"status": 1,
+			"type": 2,
+			"vpc_health_config": {
+				"create_time": "2021-07-05T09:29:38Z",
+				"http_code": "201,202,203",
+				"id": "caa3f8122eef4ce98794e84cf9fc5543",
+				"method": "GET",
+				"path": "/",
+				"port": 8080,
+				"protocol": "https",
+				"threshold_abnormal": 5,
+				"threshold_normal": 2,
+				"time_interval": 10,
+				"timeout": 5,
+				"vpc_channel_id": "328d1d563eba4ff084533188b84b9f8d"
+			}
+		}
+	]
+}
+`
+)
+
+var (
+	createOpts = &channels.ChannelOpts{
+		Name: "terraform_test",
+		Type: 2,
+		Members: []channels.MemberInfo{
+			{
+				EcsId:   "dfe1f776-dd07-4ec0-912f-47525679d76a",
+				EcsName: "terraform_test",
+				Weight:  1,
+			},
+		},
+		VpcHealthConfig: channels.VpcHealthConfig{
+			Protocol:          "https",
+			Path:              "/",
+			Method:            "GET",
+			Port:              8080,
+			ThresholdAbnormal: 5,
+			ThresholdNormal:   2,
+			TimeInterval:      10,
+			Timeout:           5,
+			HttpCodes:         "201,202,203",
+			EnableClientSsl:   false,
+		},
+		Port:            8080,
+		BalanceStrategy: 1,
+		MemberType:      "ecs",
+	}
+
+	expectedCreateResponseData = &channels.VpcChannel{
+		Id:              "328d1d563eba4ff084533188b84b9f8d",
+		Name:            "terraform_test",
+		CreateTime:      "2021-07-05T09:29:38Z",
+		MemberType:      "ecs",
+		Status:          1,
+		Type:            2,
+		BalanceStrategy: 1,
+		Port:            8080,
+	}
+
+	expectedGetResponseData = &channels.VpcChannel{
+		Id:              "328d1d563eba4ff084533188b84b9f8d",
+		BalanceStrategy: 1,
+		CreateTime:      "2021-07-05T09:29:38Z",
+		MemberType:      "ecs",
+		Members: []channels.MemberInfo{
+			{
+				EcsId:   "dfe1f776-dd07-4ec0-912f-47525679d76a",
+				EcsName: "terraform_test",
+				Weight:  1,
+				Host:    "192.168.9.195",
+			},
+		},
+		Name:   "terraform_test",
+		Port:   8080,
+		Status: 1,
+		Type:   2,
+		VpcHealthConfig: channels.VpcHealthConfig{
+			Protocol:          "https",
+			Path:              "/",
+			Method:            "GET",
+			Port:              8080,
+			ThresholdNormal:   2,
+			ThresholdAbnormal: 5,
+			HttpCodes:         "201,202,203",
+			TimeInterval:      10,
+			Timeout:           5,
+		},
+	}
+
+	expectedListResponseData = []channels.VpcChannel{
+		{
+			Id:              "328d1d563eba4ff084533188b84b9f8d",
+			BalanceStrategy: 1,
+			CreateTime:      "2021-07-05T09:29:38Z",
+			MemberType:      "ecs",
+			Members: []channels.MemberInfo{
+				{
+					EcsId:   "dfe1f776-dd07-4ec0-912f-47525679d76a",
+					EcsName: "terraform_test",
+					Weight:  1,
+					Host:    "192.168.9.195",
+				},
+			},
+			Name:   "terraform_test",
+			Port:   8080,
+			Status: 1,
+			Type:   2,
+			VpcHealthConfig: channels.VpcHealthConfig{
+				Protocol:          "https",
+				Path:              "/",
+				Method:            "GET",
+				Port:              8080,
+				ThresholdNormal:   2,
+				ThresholdAbnormal: 5,
+				HttpCodes:         "201,202,203",
+				TimeInterval:      10,
+				Timeout:           5,
+			},
+		},
+	}
+)
+
+func handleV2VpcChannelCreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/b510b8e8ef1442c0a94cdfc551af0ec3/vpc-channels",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedCreateResponse)
+		})
+}
+
+func handleV2VpcChannelGet(t *testing.T) {
+	th.Mux.HandleFunc("/instances/b510b8e8ef1442c0a94cdfc551af0ec3/vpc-channels/328d1d563eba4ff084533188b84b9f8d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleV2VpcChannelList(t *testing.T) {
+	th.Mux.HandleFunc("/instances/b510b8e8ef1442c0a94cdfc551af0ec3/vpc-channels",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedListResponse)
+		})
+}
+
+func handleV2VpcChannelUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/b510b8e8ef1442c0a94cdfc551af0ec3/vpc-channels/328d1d563eba4ff084533188b84b9f8d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleV2VpcChannelDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/b510b8e8ef1442c0a94cdfc551af0ec3/vpc-channels/328d1d563eba4ff084533188b84b9f8d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNoContent)
+		})
+}

--- a/openstack/apigw/v2/channels/testing/requests_test.go
+++ b/openstack/apigw/v2/channels/testing/requests_test.go
@@ -1,0 +1,66 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/channels"
+
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateV2VpcChannel(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2VpcChannelCreate(t)
+
+	actual, err := channels.Create(client.ServiceClient(), "b510b8e8ef1442c0a94cdfc551af0ec3",
+		createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestGetV2VpcChannel(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2VpcChannelGet(t)
+
+	actual, err := channels.Get(client.ServiceClient(), "b510b8e8ef1442c0a94cdfc551af0ec3",
+		"328d1d563eba4ff084533188b84b9f8d").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestListV2VpcChannel(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2VpcChannelList(t)
+
+	pages, err := channels.List(client.ServiceClient(), "b510b8e8ef1442c0a94cdfc551af0ec3",
+		channels.ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := channels.ExtractInstances(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV2VpcChannel(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2VpcChannelUpdate(t)
+
+	actual, err := channels.Update(client.ServiceClient(), "b510b8e8ef1442c0a94cdfc551af0ec3",
+		"328d1d563eba4ff084533188b84b9f8d", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestDeleteV2VpcChannel(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2VpcChannelDelete(t)
+
+	err := channels.Delete(client.ServiceClient(), "b510b8e8ef1442c0a94cdfc551af0ec3",
+		"328d1d563eba4ff084533188b84b9f8d").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/apigw/v2/channels/urls.go
+++ b/openstack/apigw/v2/channels/urls.go
@@ -1,0 +1,27 @@
+package channels
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+func buildRootPath(instanceId string) string {
+	return fmt.Sprintf("instances/%s/vpc-channels", instanceId)
+}
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(buildRootPath(instanceId))
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, chanId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), chanId)
+}
+
+func membersURL(c *golangsdk.ServiceClient, instanceId, chanId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), chanId, "members")
+}
+
+func memberURL(c *golangsdk.ServiceClient, instanceId, chanId, memberId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), chanId, "members", memberId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- In order to support APIG service through terraform, the vpc channel sdk needs to be added.
- The APIG contains:
  - Dedicated instance
  - Application
  - Group
  - Environment
    - Environment variables
  - API
    - ACL
    - Request throttling policy
    - Custom Authorize
    - Responses
  - **VPC Channel**
  - Domains
  - ...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. add some methods to vpc channel sdk:
  - Create
  - Get
  - List
  - Update
  - Delete
  - Add Backend
  - List Backend
  - Remove Backend
2. add test for Create, Get, List, Update and Delete methods.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2VpcChannel
--- PASS: TestCreateV2VpcChannel (0.00s)
=== RUN   TestGetV2VpcChannel
--- PASS: TestGetV2VpcChannel (0.00s)
=== RUN   TestListV2VpcChannel
--- PASS: TestListV2VpcChannel (0.00s)
=== RUN   TestUpdateV2VpcChannel
--- PASS: TestUpdateV2VpcChannel (0.00s)
=== RUN   TestDeleteV2VpcChannel
--- PASS: TestDeleteV2VpcChannel (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/channels/testing    0.028s
```