### PR TITLE
Fix the problems caused by using global variables.

### DIFF
--- a/openstack/mls/v1/instances/requests.go
+++ b/openstack/mls/v1/instances/requests.go
@@ -77,6 +77,8 @@ func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 
 //get an instance with detailed information by id
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = client.Get(resourceURL(client, id), &r.Body, &RequestOpts)
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }

--- a/openstack/rds/v3/configurations/requests.go
+++ b/openstack/rds/v3/configurations/requests.go
@@ -88,7 +88,9 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 
 // Get retrieves a particular Configuration based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &RequestOpts)
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &golangsdk.RequestOpts{
+        MoreHeaders: RequestOpts.MoreHeaders,
+    })
 	return
 }
 

--- a/openstack/sdrs/v1/drill/requests.go
+++ b/openstack/sdrs/v1/drill/requests.go
@@ -73,7 +73,9 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 
 // Get retrieves a particular dr-drill based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &requestOpts)
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &golangsdk.RequestOpts{
+        MoreHeaders: requestOpts.MoreHeaders,
+    })
 	return
 }
 

--- a/openstack/sdrs/v1/protectedinstances/requests.go
+++ b/openstack/sdrs/v1/protectedinstances/requests.go
@@ -80,7 +80,9 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 
 // Get retrieves a particular Instance based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &RequestOpts)
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &golangsdk.RequestOpts{
+        MoreHeaders: RequestOpts.MoreHeaders,
+    })
 	return
 }
 

--- a/openstack/sdrs/v1/protectiongroups/requests.go
+++ b/openstack/sdrs/v1/protectiongroups/requests.go
@@ -80,7 +80,9 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 
 // Get retrieves a particular Group based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &RequestOpts)
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 

--- a/openstack/sdrs/v1/replications/requests.go
+++ b/openstack/sdrs/v1/replications/requests.go
@@ -74,7 +74,9 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 
 // Get retrieves a particular Replication based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &RequestOpts)
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 

--- a/openstack/waf/v1/falsealarmmasking_rules/requests.go
+++ b/openstack/waf/v1/falsealarmmasking_rules/requests.go
@@ -78,7 +78,9 @@ func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
 
 // List retrieves falsealarmmasking rules.
 func List(c *golangsdk.ServiceClient, policyID string) (r ListResult) {
-	_, r.Err = c.Get(rootURL(c, policyID), &r.Body, &RequestOpts)
+	_, r.Err = c.Get(rootURL(c, policyID), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 

--- a/openstack/waf/v1/policies/requests.go
+++ b/openstack/waf/v1/policies/requests.go
@@ -105,7 +105,9 @@ func UpdateHosts(c *golangsdk.ServiceClient, policyID string, opts UpdateHostsOp
 
 // Get retrieves a particular policy based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &RequestOpts)
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &golangsdk.RequestOpts{
+        MoreHeaders: RequestOpts.MoreHeaders,
+    })
 	return
 }
 

--- a/openstack/waf/v1/whiteblackip_rules/requests.go
+++ b/openstack/waf/v1/whiteblackip_rules/requests.go
@@ -68,7 +68,9 @@ func Update(c *golangsdk.ServiceClient, policyID, ruleID string, opts UpdateOpts
 
 // Get retrieves a particular whiteblackip rule based on its unique ID.
 func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, &RequestOpts)
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
 	return
 }
 

--- a/openstack/waf_hw/v1/policies/requests.go
+++ b/openstack/waf_hw/v1/policies/requests.go
@@ -108,7 +108,11 @@ func UpdateHosts(c *golangsdk.ServiceClient, policyId string, opts UpdateHostsOp
 
 // Get retrieves a particular policy based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &RequestOpts)
+	reqOpt := &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, reqOpt)
 	return
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Use global `RequestOpts` in http requests will cause the problem of null values.
When there are multiple requests for the same resource, only the earliest returned request will get a responseBody that can be successfully parsed.
Other requests are successfully responsed, but the responseBody of `RequestOpts` is null, and all fields of the object returned by the `Extract` function are default values.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- Some resources do not run unit tests because they have no services.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
# Acceptance Steps Performed

### HuaweiCloud Provider
- huaweicloud_rds_parametergroup 
```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccRdsConfigurationV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccRdsConfigurationV3_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsConfigurationV3_basic
=== PAUSE TestAccRdsConfigurationV3_basic
=== CONT  TestAccRdsConfigurationV3_basic
--- PASS: TestAccRdsConfigurationV3_basic (34.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       34.597s

```

- resource_huaweicloud_lts_stream
```
make testacc TEST='./huaweicloud' TESTARGS='-run TestAccLogTankStreamV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccLogTankStreamV2_basic -timeout 360m -parallel 4
=== RUN   TestAccLogTankStreamV2_basic
=== PAUSE TestAccLogTankStreamV2_basic
=== CONT  TestAccLogTankStreamV2_basic
--- PASS: TestAccLogTankStreamV2_basic (29.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       29.734s

```

### FlexibleEngine Provider
- flexibleengine_rds_parametergroup_v3
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccRdsConfigurationV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccRdsConfigurationV3_basic -timeout 720m
=== RUN   TestAccRdsConfigurationV3_basic
--- PASS: TestAccRdsConfigurationV3_basic (68.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 68.320s

```

- flexibleengine_sdrs_protectiongroup_v1
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccSdrsDrillV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccSdrsDrillV1_basic -timeout 720m
=== RUN   TestAccSdrsDrillV1_basic
--- PASS: TestAccSdrsDrillV1_basic (57.42s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 57.503s

```
