### PR TITLE
Update the type of description parameter

### DIFF
--- a/openstack/apigw/v2/environments/requests.go
+++ b/openstack/apigw/v2/environments/requests.go
@@ -14,7 +14,7 @@ type EnvironmentOpts struct {
 	// Description of the environment, which can contain a maximum of 255 characters,
 	// and the angle brackets (< and >) are not allowed.
 	// Chinese characters must be in UTF-8 or Unicode format.
-	Description string `json:"remark,omitempty"`
+	Description *string `json:"remark,omitempty"`
 }
 
 type EnvironmentOptsBuilder interface {

--- a/openstack/apigw/v2/environments/testing/fixtures.go
+++ b/openstack/apigw/v2/environments/testing/fixtures.go
@@ -67,9 +67,10 @@ const (
 )
 
 var (
+	createDesc = "Updated by script"
 	createOpts = &environments.EnvironmentOpts{
 		Name:        "terraform_test",
-		Description: "Created by script",
+		Description: &createDesc,
 	}
 
 	expectedCreateResponseData = &environments.Environment{
@@ -79,9 +80,10 @@ var (
 		CreateTime:  "2021-06-22T12:11:28.18948645Z",
 	}
 
+	updateDesc = "Updated by script"
 	updateOpts = &environments.EnvironmentOpts{
 		Name:        "terraform_test",
-		Description: "Created by script",
+		Description: &updateDesc,
 	}
 
 	expectedUpdateResponseData = &environments.Environment{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Modify the description type to a pointer to solve the problem that the description cannot update to empty.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. modify the description type to a pointer.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2Environment
--- PASS: TestCreateV2Environment (0.00s)
=== RUN   TestListV2Environment
--- PASS: TestListV2Environment (0.00s)
=== RUN   TestUpdateV2Environment
--- PASS: TestUpdateV2Environment (0.00s)
=== RUN   TestDeleteV2Environment
--- PASS: TestDeleteV2Environment (0.00s)
=== RUN   TestCreateV2EnvironmentVariable
--- PASS: TestCreateV2EnvironmentVariable (0.00s)
=== RUN   TestGetV2EnvironmentVariable
--- PASS: TestGetV2EnvironmentVariable (0.00s)
=== RUN   TestListV2EnvironmentVariable
--- PASS: TestListV2EnvironmentVariable (0.00s)
=== RUN   TestDeleteV2EnvironmentVariable
--- PASS: TestDeleteV2EnvironmentVariable (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/environments/testing        0.017s
```