### PR TITLE
Set param type of the description to pointer

### DIFF
--- a/openstack/apigw/v2/apigroups/requests.go
+++ b/openstack/apigw/v2/apigroups/requests.go
@@ -14,7 +14,7 @@ type GroupOpts struct {
 	// Description of the API group, which can contain a maximum of 255 characters,
 	// and the angle brackets (< and >) are not allowed.
 	// Chinese characters must be in UTF-8 or Unicode format.
-	Description string `json:"remark,omitempty"`
+	Description *string `json:"remark,omitempty"`
 }
 
 type CreateOptsBuilder interface {

--- a/openstack/apigw/v2/apigroups/testing/fixtures.go
+++ b/openstack/apigw/v2/apigroups/testing/fixtures.go
@@ -65,9 +65,10 @@ const (
 )
 
 var (
+	createDesc = "Created by script"
 	createOpts = &apigroups.GroupOpts{
 		Name:        "terraform_test",
-		Description: "Created by script",
+		Description: &createDesc,
 	}
 
 	expectedCreateResponseData = &apigroups.Group{
@@ -117,9 +118,10 @@ var (
 		},
 	}
 
+	updateDesc = "Updated by script"
 	updateOpts = apigroups.GroupOpts{
 		Name:        "terraform_test_update",
-		Description: "Updated by script",
+		Description: &updateDesc,
 	}
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Modify the description type to a pointer to solve the problem that the description cannot update to empty.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. Set param type of the description to pointer
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2Group
--- PASS: TestCreateV2Group (0.00s)
=== RUN   TestGetV2Group
--- PASS: TestGetV2Group (0.00s)
=== RUN   TestListV2Group
--- PASS: TestListV2Group (0.00s)
=== RUN   TestUpdateV2Group
--- PASS: TestUpdateV2Group (0.00s)
=== RUN   TestDeleteV2Group
--- PASS: TestDeleteV2Group (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/apigroups/testing   0.015s
```
