### PR TITLE
New APIG custom authorizers sdk supported

### DIFF
--- a/openstack/apigw/v2/authorizers/requests.go
+++ b/openstack/apigw/v2/authorizers/requests.go
@@ -1,0 +1,125 @@
+package authorizers
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type CustomAuthOpts struct {
+	// Custom authorizer name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	Name string `json:"name" required:"true"`
+	// Custom authorizer type, which support 'FRONTEND' and 'BACKEND'.
+	Type string `json:"type" required:"true"`
+	// Authorizer type, and the value is 'FUNC'.
+	AuthorizerType string `json:"authorizer_type" required:"true"`
+	// Function URN.
+	AuthorizerUri string `json:"authorizer_uri" required:"true"`
+	// Indicates whether to send the body.
+	IsBodySend *bool `json:"need_body,omitempty"`
+	// Identity source.
+	Identities []AuthCreateIdentitiesReq `json:"identities,omitempty"`
+	// Maximum cache age. The maximum value is 3,600.
+	// The maximum length of time that authentication results can be cached for.
+	// A value of 0 means that results are not cached.
+	CacheAge int `json:"ttl,omitempty"`
+	// User data.
+	UserData *string `json:"user_data,omitempty"`
+}
+
+type AuthCreateIdentitiesReq struct {
+	// Parameter name.
+	Name string `json:"name" required:"true"`
+	// Parameter location, which support 'HEADER' and 'QUERY'.
+	Location string `json:"location" required:"true"`
+	// Parameter verification expression. The default value is null, indicating that no verification is performed.
+	Validation *string `json:"validation,omitempty"`
+}
+
+type CustomAuthOptsBuilder interface {
+	ToCustomAuthOptsMap() (map[string]interface{}, error)
+}
+
+func (opts CustomAuthOpts) ToCustomAuthOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method to create a new custom authorizer.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts CustomAuthOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToCustomAuthOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method to udpate an existing custom authorizer.
+func Update(client *golangsdk.ServiceClient, instanceId, authId string, opts CustomAuthOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToCustomAuthOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, authId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtain an existing custom authorizer.
+func Get(client *golangsdk.ServiceClient, instanceId, authId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, authId), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// ID.
+	Id string `q:"id"`
+	// Name.
+	Name string `q:"name"`
+	// Custom authorizer type.
+	Type string `q:"type"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+}
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more custom authorizers for the instance according to the
+// query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return CustomAuthPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing custom authorizer.
+func Delete(client *golangsdk.ServiceClient, instanceId, authId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, authId), nil)
+	return
+}

--- a/openstack/apigw/v2/authorizers/requests.go
+++ b/openstack/apigw/v2/authorizers/requests.go
@@ -5,6 +5,8 @@ import (
 	"github.com/huaweicloud/golangsdk/pagination"
 )
 
+// CustomAuthOpts is a struct which will be used to create a new custom authorizer or
+// update an existing custom authorizer.
 type CustomAuthOpts struct {
 	// Custom authorizer name, which can contain 3 to 64 characters, starting with a letter.
 	// Only letters, digits, and underscores (_) are allowed.
@@ -14,7 +16,7 @@ type CustomAuthOpts struct {
 	// Authorizer type, and the value is 'FUNC'.
 	AuthorizerType string `json:"authorizer_type" required:"true"`
 	// Function URN.
-	AuthorizerUri string `json:"authorizer_uri" required:"true"`
+	AuthorizerURI string `json:"authorizer_uri" required:"true"`
 	// Indicates whether to send the body.
 	IsBodySend *bool `json:"need_body,omitempty"`
 	// Identity source.
@@ -22,11 +24,12 @@ type CustomAuthOpts struct {
 	// Maximum cache age. The maximum value is 3,600.
 	// The maximum length of time that authentication results can be cached for.
 	// A value of 0 means that results are not cached.
-	CacheAge int `json:"ttl,omitempty"`
+	TTL *int `json:"ttl,omitempty"`
 	// User data.
 	UserData *string `json:"user_data,omitempty"`
 }
 
+// AuthCreateIdentitiesReq is an object which will be build up a indentities list.
 type AuthCreateIdentitiesReq struct {
 	// Parameter name.
 	Name string `json:"name" required:"true"`
@@ -36,10 +39,13 @@ type AuthCreateIdentitiesReq struct {
 	Validation *string `json:"validation,omitempty"`
 }
 
+// CustomAuthOptsBuilder is an interface which to support request body build of
+// the custom authorizer creation and updation.
 type CustomAuthOptsBuilder interface {
 	ToCustomAuthOptsMap() (map[string]interface{}, error)
 }
 
+// ToCustomAuthOptsMap is a method which to build a request body by the CustomAuthOpts.
 func (opts CustomAuthOpts) ToCustomAuthOptsMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
@@ -55,7 +61,7 @@ func Create(client *golangsdk.ServiceClient, instanceId string, opts CustomAuthO
 	return
 }
 
-// Update is a method to udpate an existing custom authorizer.
+// Update is a method to update an existing custom authorizer.
 func Update(client *golangsdk.ServiceClient, instanceId, authId string, opts CustomAuthOptsBuilder) (r UpdateResult) {
 	reqBody, err := opts.ToCustomAuthOptsMap()
 	if err != nil {
@@ -77,7 +83,7 @@ func Get(client *golangsdk.ServiceClient, instanceId, authId string) (r GetResul
 // ListOpts allows to filter list data using given parameters.
 type ListOpts struct {
 	// ID.
-	Id string `q:"id"`
+	ID string `q:"id"`
 	// Name.
 	Name string `q:"name"`
 	// Custom authorizer type.
@@ -89,10 +95,13 @@ type ListOpts struct {
 	Limit int `q:"limit"`
 }
 
+// ListOptsBuilder is an interface which to support request query build of
+// the custom authorizer search.
 type ListOptsBuilder interface {
 	ToListQuery() (string, error)
 }
 
+// ToListQuery is a method which to build a request query by the ListOpts.
 func (opts ListOpts) ToListQuery() (string, error) {
 	q, err := golangsdk.BuildQueryString(opts)
 	if err != nil {

--- a/openstack/apigw/v2/authorizers/results.go
+++ b/openstack/apigw/v2/authorizers/results.go
@@ -1,0 +1,81 @@
+package authorizers
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update method.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Update method.
+type GetResult struct {
+	commonResult
+}
+
+type CustomAuthorizer struct {
+	// Custom authorizer name., which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	Name string `json:"name"`
+	// Custom authorizer type, which support 'FRONTEND' and 'BACKEND'.
+	Type string `json:"type"`
+	// Authorizer type, and the value is 'FUNC'.
+	AuthorizerType string `json:"authorizer_type"`
+	// Function URN.
+	AuthorizerUri string `json:"authorizer_uri"`
+	// Identity source.
+	Identities []Identity `json:"identities"`
+	// Maximum cache age.
+	CacheAge int `json:"ttl"`
+	// User data.
+	UserData string `json:"user_data"`
+	// Indicates whether to send the body.
+	IsBodySend bool `json:"need_body"`
+	// Custom authorizer ID
+	Id string `json:"id"`
+	// Creation time.
+	CreateTime string `json:"create_time"`
+}
+
+type Identity struct {
+	// Parameter name.
+	Name string `json:"name"`
+	// Parameter location, which support 'HEADER' and 'QUERY'.
+	Location string `json:"location"`
+	// Parameter verification expression.
+	// The default value is null, indicating that no verification is performed.
+	Validation string `json:"validation"`
+}
+
+func (r commonResult) Extract() (*CustomAuthorizer, error) {
+	var s CustomAuthorizer
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// CustomAuthPage represents the response pages of the List method.
+type CustomAuthPage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractCustomAuthorizers(r pagination.Page) ([]CustomAuthorizer, error) {
+	var s []CustomAuthorizer
+	err := r.(CustomAuthPage).Result.ExtractIntoSlicePtr(&s, "authorizer_list")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/apigw/v2/authorizers/results.go
+++ b/openstack/apigw/v2/authorizers/results.go
@@ -24,6 +24,7 @@ type GetResult struct {
 	commonResult
 }
 
+// CustomAuthorizer is a struct that represents the result of Create, Update and Get methods.
 type CustomAuthorizer struct {
 	// Custom authorizer name., which can contain 3 to 64 characters, starting with a letter.
 	// Only letters, digits, and underscores (_) are allowed.
@@ -33,21 +34,22 @@ type CustomAuthorizer struct {
 	// Authorizer type, and the value is 'FUNC'.
 	AuthorizerType string `json:"authorizer_type"`
 	// Function URN.
-	AuthorizerUri string `json:"authorizer_uri"`
+	AuthorizerURI string `json:"authorizer_uri"`
 	// Identity source.
 	Identities []Identity `json:"identities"`
 	// Maximum cache age.
-	CacheAge int `json:"ttl"`
+	TTL int `json:"ttl"`
 	// User data.
 	UserData string `json:"user_data"`
 	// Indicates whether to send the body.
 	IsBodySend bool `json:"need_body"`
 	// Custom authorizer ID
-	Id string `json:"id"`
+	ID string `json:"id"`
 	// Creation time.
 	CreateTime string `json:"create_time"`
 }
 
+// Identity is an object struct that represents the elements of the Identities parameter.
 type Identity struct {
 	// Parameter name.
 	Name string `json:"name"`
@@ -69,6 +71,7 @@ type CustomAuthPage struct {
 	pagination.SinglePageBase
 }
 
+// ExtractCustomAuthorizers is a method which to extract the response to a custom authorizer list.
 func ExtractCustomAuthorizers(r pagination.Page) ([]CustomAuthorizer, error) {
 	var s []CustomAuthorizer
 	err := r.(CustomAuthPage).Result.ExtractIntoSlicePtr(&s, "authorizer_list")

--- a/openstack/apigw/v2/authorizers/testing/fixtures.go
+++ b/openstack/apigw/v2/authorizers/testing/fixtures.go
@@ -51,9 +51,9 @@ var (
 		Name:           "terraform_test",
 		Type:           "BACKEND",
 		AuthorizerType: "FUNC",
-		AuthorizerUri:  "urn:fss:ae-ad-1\\:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
+		AuthorizerURI:  "urn:fss:ae-ad-1\\:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
 		IsBodySend:     golangsdk.Disabled,
-		CacheAge:       60,
+		TTL:            golangsdk.IntToPointer(60),
 		UserData:       golangsdk.MaybeString(""),
 	}
 
@@ -61,11 +61,11 @@ var (
 		Name:           "terraform_test",
 		Type:           "BACKEND",
 		AuthorizerType: "FUNC",
-		AuthorizerUri:  "urn:fss:ae-ad-1:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
+		AuthorizerURI:  "urn:fss:ae-ad-1:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
 		CreateTime:     "2021-07-17T08:33:35Z",
-		Id:             "3b9a3dda163f4ebb8fdcbbf786bffa20",
+		ID:             "3b9a3dda163f4ebb8fdcbbf786bffa20",
 		IsBodySend:     false,
-		CacheAge:       60,
+		TTL:            60,
 		UserData:       "",
 	}
 
@@ -78,11 +78,11 @@ var (
 			Name:           "terraform_test",
 			Type:           "BACKEND",
 			AuthorizerType: "FUNC",
-			AuthorizerUri:  "urn:fss:ae-ad-1:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
+			AuthorizerURI:  "urn:fss:ae-ad-1:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
 			CreateTime:     "2021-07-17T08:33:35Z",
-			Id:             "3b9a3dda163f4ebb8fdcbbf786bffa20",
+			ID:             "3b9a3dda163f4ebb8fdcbbf786bffa20",
 			IsBodySend:     false,
-			CacheAge:       60,
+			TTL:            60,
 			UserData:       "",
 		},
 	}

--- a/openstack/apigw/v2/authorizers/testing/fixtures.go
+++ b/openstack/apigw/v2/authorizers/testing/fixtures.go
@@ -1,0 +1,143 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedGetResponse = `
+{
+	"authorizer_type": "FUNC",
+	"authorizer_uri": "urn:fss:ae-ad-1:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
+	"create_time": "2021-07-17T08:33:35Z",
+	"id": "3b9a3dda163f4ebb8fdcbbf786bffa20",
+	"name": "terraform_test",
+	"need_body": false,
+	"ttl": 60,
+	"type": "BACKEND",
+	"user_data": ""
+}
+`
+
+	expectedListResponse = `
+{
+	"authorizer_list": [
+		{
+	    	"authorizer_type": "FUNC",
+	    	"authorizer_uri": "urn:fss:ae-ad-1:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
+	    	"create_time": "2021-07-17T08:33:35Z",
+	    	"id": "3b9a3dda163f4ebb8fdcbbf786bffa20",
+	    	"name": "terraform_test",
+	    	"need_body": false,
+	    	"ttl": 60,
+	    	"type": "BACKEND",
+	    	"user_data": ""
+	  	}
+	],
+	"size": 1,
+	"total": 1
+}`
+)
+
+var (
+	createOpts = authorizers.CustomAuthOpts{
+		Name:           "terraform_test",
+		Type:           "BACKEND",
+		AuthorizerType: "FUNC",
+		AuthorizerUri:  "urn:fss:ae-ad-1\\:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
+		IsBodySend:     golangsdk.Disabled,
+		CacheAge:       60,
+		UserData:       golangsdk.MaybeString(""),
+	}
+
+	expectedGetResponseData = &authorizers.CustomAuthorizer{
+		Name:           "terraform_test",
+		Type:           "BACKEND",
+		AuthorizerType: "FUNC",
+		AuthorizerUri:  "urn:fss:ae-ad-1:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
+		CreateTime:     "2021-07-17T08:33:35Z",
+		Id:             "3b9a3dda163f4ebb8fdcbbf786bffa20",
+		IsBodySend:     false,
+		CacheAge:       60,
+		UserData:       "",
+	}
+
+	listOpts = &authorizers.ListOpts{
+		Name: "terraform_test",
+	}
+
+	expectedListResponseData = []authorizers.CustomAuthorizer{
+		{
+			Name:           "terraform_test",
+			Type:           "BACKEND",
+			AuthorizerType: "FUNC",
+			AuthorizerUri:  "urn:fss:ae-ad-1:0c22dd73f6005a032f3ec0061de74dbf:function:default:terraform_test",
+			CreateTime:     "2021-07-17T08:33:35Z",
+			Id:             "3b9a3dda163f4ebb8fdcbbf786bffa20",
+			IsBodySend:     false,
+			CacheAge:       60,
+			UserData:       "",
+		},
+	}
+)
+
+func handleV2CustomAuthorizerCreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/authorizers",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleV2CustomAuthorizerGet(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/authorizers/0d2a523974a14fe1a25c1bc2f61b2d9d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleV2CustomAuthorizerList(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/authorizers",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedListResponse)
+		})
+}
+
+func handleV2CustomAuthorizerUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/authorizers/0d2a523974a14fe1a25c1bc2f61b2d9d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleV2CustomAuthorizerDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/authorizers/0d2a523974a14fe1a25c1bc2f61b2d9d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNoContent)
+		})
+}

--- a/openstack/apigw/v2/authorizers/testing/requests_test.go
+++ b/openstack/apigw/v2/authorizers/testing/requests_test.go
@@ -1,0 +1,65 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateV2CustomAuthorizer(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2CustomAuthorizerCreate(t)
+
+	actual, err := authorizers.Create(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestGetV2CustomAuthorizer(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2CustomAuthorizerGet(t)
+
+	actual, err := authorizers.Get(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"0d2a523974a14fe1a25c1bc2f61b2d9d").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestListV2CustomAuthorizer(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2CustomAuthorizerList(t)
+
+	pages, err := authorizers.List(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := authorizers.ExtractCustomAuthorizers(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV2CustomAuthorizer(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2CustomAuthorizerUpdate(t)
+
+	actual, err := authorizers.Update(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"0d2a523974a14fe1a25c1bc2f61b2d9d", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestDeleteV2CustomAuthorizer(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2CustomAuthorizerDelete(t)
+
+	err := authorizers.Delete(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"0d2a523974a14fe1a25c1bc2f61b2d9d").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/apigw/v2/authorizers/urls.go
+++ b/openstack/apigw/v2/authorizers/urls.go
@@ -1,0 +1,13 @@
+package authorizers
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "instances"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(rootPath, instanceId, "authorizers")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, id string) string {
+	return c.ServiceURL(rootPath, instanceId, "authorizers", id)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- In order to support APIG service through terraform, the custom authorizer sdk needs to be added.
- The APIG contains:
  - Dedicated instance
  - Application
  - Group
  - Environment
    - Environment variables
  - API
    - ACL
    - Request throttling policy
    - **Custom Authorizer**
    - Responses
  - VPC Channel
  - Domains
  - ...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. New apig custom authorizers sdk supported:
  a. Create
  b. Update
  c. Get
  d. List
  e. Delete
2. Related method acc test supported.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2CustomAuthorizer
--- PASS: TestCreateV2CustomAuthorizer (0.00s)
=== RUN   TestGetV2CustomAuthorizer
--- PASS: TestGetV2CustomAuthorizer (0.00s)
=== RUN   TestListV2CustomAuthorizer
--- PASS: TestListV2CustomAuthorizer (0.00s)
=== RUN   TestDeleteV2CustomAuthorizer
--- PASS: TestDeleteV2CustomAuthorizer (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/authorizers/testing 0.014s
```
