### PR TITLE
New APIG throttling policy sdk supported

### DIFF
--- a/openstack/apigw/v2/throttles/requests.go
+++ b/openstack/apigw/v2/throttles/requests.go
@@ -1,0 +1,136 @@
+package throttles
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type ThrottlingPolicyOpts struct {
+	// Maximum number of times an API can be accessed within a specified period.
+	// The value of this parameter cannot exceed the default limit 200 TPS.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	ApiCallLimits int `json:"api_call_limits" required:"true"`
+	// Request throttling policy name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name" required:"true"`
+	// Period of time for limiting the number of API calls.
+	// This parameter applies with each of the preceding three API call limits.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	TimeInterval int `json:"time_interval" required:"true"`
+	// Time unit for limiting the number of API calls.
+	// The valid values are as following:
+	//     SECOND
+	//     MINUTE
+	//     HOUR
+	//     DAY
+	TimeUnit string `json:"time_unit" required:"true"`
+	// Maximum number of times the API can be accessed by an app within the same period.
+	// The value of this parameter must be less than that of user_call_limits.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	AppCallLimits int `json:"app_call_limits,omitempty"`
+	// Description of the request throttling policy, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark,omitempty"`
+	// Type of the request throttling policy.
+	// 1: exclusive, limiting the maximum number of times a single API bound to the policy can be called within
+	// the specified period.
+	// 2: shared, limiting the maximum number of times all APIs bound to the policy can be called within the
+	// specified period.
+	Type int `json:"type,omitempty"`
+	// Maximum number of times the API can be accessed by a user within the same period.
+	// The value of this parameter must be less than that of api_call_limits.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	UserCallLimits int `json:"user_call_limits,omitempty"`
+	// Maximum number of times the API can be accessed by an IP address within the same period.
+	// The value of this parameter must be less than that of api_call_limits.
+	// This value must be a positive integer and cannot exceed 2,147,483,647.
+	IpCallLimits int `json:"ip_call_limits,omitempty"`
+}
+
+type ThrottlingPolicyOptsBuilder interface {
+	ToThrottlingPolicyOptsMap() (map[string]interface{}, error)
+}
+
+func (opts ThrottlingPolicyOpts) ToThrottlingPolicyOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a new throttling policy.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts ThrottlingPolicyOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToThrottlingPolicyOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method by which to udpate an existing throttle policy.
+func Update(client *golangsdk.ServiceClient, instanceId, policyId string,
+	opts ThrottlingPolicyOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToThrottlingPolicyOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, policyId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtain an existing APIG throttling policy by policy ID.
+func Get(client *golangsdk.ServiceClient, instanceId, policyId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, policyId), &r.Body, nil)
+	return
+}
+
+type ListOpts struct {
+	// Request throttling policy ID.
+	Id string `q:"id"`
+	// Request throttling policy name.
+	Name string `q:"name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+	// Parameter name (name) for exact matching.
+	PreciseSearch string `q:"precise_search"`
+}
+
+type ListOptsBuilder interface {
+	ToListQuery() (string, error)
+}
+
+func (opts ListOpts) ToListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more throttling policies according to the query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ThorttlePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing throttling policy.
+func Delete(client *golangsdk.ServiceClient, instanceId, policyId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, policyId), nil)
+	return
+}

--- a/openstack/apigw/v2/throttles/results.go
+++ b/openstack/apigw/v2/throttles/results.go
@@ -1,0 +1,87 @@
+package throttles
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update method.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Get method.
+type GetResult struct {
+	commonResult
+}
+
+type ThrottlingPolicy struct {
+	// Number of APIs to which the request throttling policy has been bound.
+	BindNum int `json:"bind_num"`
+	// Indicates whether an excluded request throttling configuration has been created.
+	// 1: yes
+	// 2: no
+	IsIncludeSpecialThrottle int `json:"is_include_special_throttle"`
+	// Creation time.
+	CreateTime string `json:"create_time"`
+	// Description.
+	Description string `json:"remark"`
+	// Type of the request throttling policy.
+	// 1: exclusive, limiting the maximum number of times a single API bound to the policy can be called within
+	// the specified period.
+	// 2: shared, limiting the maximum number of times all APIs bound to the policy can be called within the
+	// specified period.
+	Type int `json:"type"`
+	// Period of time for limiting the number of API calls.
+	TimeInterval int `json:"time_interval"`
+	// Maximum number of times the API can be accessed by an IP address within the same period.
+	IpCallLimits int `json:"ip_call_limits"`
+	// Maximum number of times the API can be accessed by an app within the same period.
+	AppCallLimits int `json:"app_call_limits"`
+	// Request throttling policy name.
+	Name string `json:"name"`
+	// Time unit for limiting the number of API calls.
+	// The valid values are as following:
+	//     SECOND
+	//     MINUTE
+	//     HOUR
+	//     DAY
+	TimeUnit string `json:"time_unit"`
+	// Maximum number of times an API can be accessed within a specified period.
+	ApiCallLimits int `json:"api_call_limits"`
+	// Request throttling policy ID.
+	Id string `json:"id"`
+	// Maximum number of times the API can be accessed by a user within the same period.
+	UserCallLimits int `json:"user_call_limits"`
+}
+
+func (r commonResult) Extract() (*ThrottlingPolicy, error) {
+	var s ThrottlingPolicy
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// The ThorttlePage represents the result of a List operation.
+type ThorttlePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractPolicies its Extract method to interpret it as a throttling policy array.
+func ExtractPolicies(r pagination.Page) ([]ThrottlingPolicy, error) {
+	var s []ThrottlingPolicy
+	err := r.(ThorttlePage).Result.ExtractIntoSlicePtr(&s, "throttles")
+	return s, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/apigw/v2/throttles/testing/fixtures.go
+++ b/openstack/apigw/v2/throttles/testing/fixtures.go
@@ -1,0 +1,152 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedCreateResponse = `
+{
+	"api_call_limits": 50,
+	"app_call_limits": 20,
+	"bind_num": 0,
+	"create_time": "2021-07-19T08:46:39.799181829Z",
+	"id": "c481043838f64bcd82c7b0c38907d59d",
+	"ip_call_limits": 15,
+	"name": "terraform_test",
+	"remark": "Created by script",
+	"time_interval": 10,
+	"time_unit": "MINUTE",
+	"type": 1,
+	"user_call_limits": 20
+}`
+
+	expectedListResponse = `
+{
+	"throttles": [
+		{
+			"api_call_limits": 50,
+			"app_call_limits": 20,
+			"bind_num": 0,
+			"create_time": "2021-07-19T08:46:39.799181829Z",
+			"id": "c481043838f64bcd82c7b0c38907d59d",
+			"ip_call_limits": 15,
+			"name": "terraform_test",
+			"remark": "Created by script",
+			"time_interval": 10,
+			"time_unit": "MINUTE",
+			"type": 1,
+			"user_call_limits": 20
+		}
+	]
+}`
+)
+
+var (
+	createOpts = &throttles.ThrottlingPolicyOpts{
+		Name:           "terraform_test",
+		Type:           1,
+		TimeInterval:   10,
+		TimeUnit:       "MINUTE",
+		ApiCallLimits:  50,
+		UserCallLimits: 20,
+		AppCallLimits:  20,
+		IpCallLimits:   15,
+		Description:    "Created by script",
+	}
+
+	expectedCreateResponseData = &throttles.ThrottlingPolicy{
+		Name:           "terraform_test",
+		Type:           1,
+		TimeInterval:   10,
+		TimeUnit:       "MINUTE",
+		ApiCallLimits:  50,
+		UserCallLimits: 20,
+		AppCallLimits:  20,
+		IpCallLimits:   15,
+		Description:    "Created by script",
+		BindNum:        0,
+		CreateTime:     "2021-07-19T08:46:39.799181829Z",
+		Id:             "c481043838f64bcd82c7b0c38907d59d",
+	}
+
+	listOpts = throttles.ListOpts{
+		Name: "terraform_test",
+	}
+
+	expectedListResponseData = []throttles.ThrottlingPolicy{
+		{
+			Name:           "terraform_test",
+			Type:           1,
+			TimeInterval:   10,
+			TimeUnit:       "MINUTE",
+			ApiCallLimits:  50,
+			UserCallLimits: 20,
+			AppCallLimits:  20,
+			IpCallLimits:   15,
+			Description:    "Created by script",
+			BindNum:        0,
+			CreateTime:     "2021-07-19T08:46:39.799181829Z",
+			Id:             "c481043838f64bcd82c7b0c38907d59d",
+		},
+	}
+)
+
+func handleV2ThrottlingPolicyCreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedCreateResponse)
+		})
+}
+
+func handleV2ThrottlingPolicyGet(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles/c481043838f64bcd82c7b0c38907d59d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedCreateResponse)
+		})
+}
+
+func handleV2ThrottlingPolicyList(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedListResponse)
+	})
+}
+
+func handleV2ThrottlingPolicyUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles/c481043838f64bcd82c7b0c38907d59d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedCreateResponse)
+		})
+}
+
+func handleV2ThrottlingPolicyDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles/c481043838f64bcd82c7b0c38907d59d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNoContent)
+		})
+}

--- a/openstack/apigw/v2/throttles/testing/requests_test.go
+++ b/openstack/apigw/v2/throttles/testing/requests_test.go
@@ -1,0 +1,64 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateV2ThrottlingPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ThrottlingPolicyCreate(t)
+
+	actual, err := throttles.Create(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestGetV2ThrottlingPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ThrottlingPolicyGet(t)
+
+	actual, err := throttles.Get(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"c481043838f64bcd82c7b0c38907d59d").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestListV2ThrottlingPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ThrottlingPolicyList(t)
+
+	pages, err := throttles.List(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := throttles.ExtractPolicies(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV2ThrottlingPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ThrottlingPolicyUpdate(t)
+
+	actual, err := throttles.Update(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"c481043838f64bcd82c7b0c38907d59d", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestDeleteV2ThrottlingPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2ThrottlingPolicyDelete(t)
+
+	err := throttles.Delete(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"c481043838f64bcd82c7b0c38907d59d").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/apigw/v2/throttles/urls.go
+++ b/openstack/apigw/v2/throttles/urls.go
@@ -1,0 +1,19 @@
+package throttles
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+func buildRootPath(instanceId string) string {
+	return fmt.Sprintf("instances/%s/throttles", instanceId)
+}
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(buildRootPath(instanceId))
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, policyId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), policyId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- In order to support APIG service through terraform, the throttling policy sdk needs to be added.
- The APIG contains:
  - Dedicated instance
  - Application
  - Group
  - Environment
    - Environment variables
  - API
    - ACL
    - **Request throttling policy**
    - Custom Authorize
    - Responses
  - VPC Channel
  - Domains
  - ...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. New apig throttling policy sdk supported:
  a. Create
  b. Update
  c. Get
  d. List
  e. Delete
2. Related method acc test supported.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2ThrottlingPolicy
--- PASS: TestCreateV2ThrottlingPolicy (0.00s)
=== RUN   TestGetV2ThrottlingPolicy
--- PASS: TestGetV2ThrottlingPolicy (0.00s)
=== RUN   TestListV2ThrottlingPolicy
--- PASS: TestListV2ThrottlingPolicy (0.00s)
=== RUN   TestUpdateV2ThrottlingPolicy
--- PASS: TestUpdateV2ThrottlingPolicy (0.00s)
=== RUN   TestDeleteV2ThrottlingPolicy
--- PASS: TestDeleteV2ThrottlingPolicy (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles/testing   0.258s
```
