### PR TITLE
Add special throttling policy to throttles sdk

### DIFF
--- a/openstack/apigw/v2/throttles/requests.go
+++ b/openstack/apigw/v2/throttles/requests.go
@@ -134,3 +134,120 @@ func Delete(client *golangsdk.ServiceClient, instanceId, policyId string) (r Del
 	_, r.Err = client.Delete(resourceURL(client, instanceId, policyId), nil)
 	return
 }
+
+// SpecThrottleCreateOpts is a struct which will be used to create a new special throttling policy.
+type SpecThrottleCreateOpts struct {
+	// Maximum number of times the excluded object can access an API within the throttling period.
+	CallLimits int `json:"call_limits" required:"true"`
+	// Excluded app ID or excluded account ID.
+	ObjectId string `json:"object_id" required:"true"`
+	// Excluded object type, which supports APP and USER.
+	ObjectType string `json:"object_type" required:"true"`
+}
+
+// SpecThrottleCreateOptsBuilder is an interface which to support request body build of
+// the special throttling policy creation.
+type SpecThrottleCreateOptsBuilder interface {
+	ToSpecThrottleCreateOptsMap() (map[string]interface{}, error)
+}
+
+// ToSpecThrottleCreateOptsMap is a method which to build a request body by the SpecThrottleCreateOpts.
+func (opts SpecThrottleCreateOpts) ToSpecThrottleCreateOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// CreateSpecThrottle is a method by which to create a new special throttling policy.
+func CreateSpecThrottle(client *golangsdk.ServiceClient, instanceId, policyId string,
+	opts SpecThrottleCreateOptsBuilder) (r SpecThrottleResult) {
+	reqBody, err := opts.ToSpecThrottleCreateOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(specRootURL(client, instanceId, policyId), reqBody, &r.Body, nil)
+	return
+}
+
+// SpecThrottleUpdateOpts is a struct which will be used to update an existing special throttling policy.
+type SpecThrottleUpdateOpts struct {
+	// Maximum number of times the excluded object can access an API within the throttling period.
+	CallLimits int `json:"call_limits" required:"true"`
+}
+
+// SpecThrottleUpdateOptsBuilder is an interface which to support request body build of
+// the special throttling policy updation.
+type SpecThrottleUpdateOptsBuilder interface {
+	ToSpecThrottleUpdateOptsMap() (map[string]interface{}, error)
+}
+
+// ToSpecThrottleUpdateOptsMap is a method which to build a request body by the SpecThrottleUpdateOpts.
+func (opts SpecThrottleUpdateOpts) ToSpecThrottleUpdateOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// UpdateSpecThrottle is a method by which to update an existing special throttle policy.
+func UpdateSpecThrottle(client *golangsdk.ServiceClient, instanceId, policyId, strategyId string,
+	opts SpecThrottleUpdateOptsBuilder) (r SpecThrottleResult) {
+	reqBody, err := opts.ToSpecThrottleUpdateOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(specResourceURL(client, instanceId, policyId, strategyId), reqBody, &r.Body,
+		&golangsdk.RequestOpts{
+			OkCodes: []int{200},
+		})
+	return
+}
+
+// SpecThrottlesListOpts allows to filter list data using given parameters.
+type SpecThrottlesListOpts struct {
+	// Object type, which can be APP or USER.
+	ObjectType string `q:"object_type"`
+	// Name of an excluded app.
+	AppName string `q:"app_name"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The valid values are range form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+}
+
+// SpecThrottlesListOptsBuilder is an interface which to support request query build of
+// the special throttling policies search.
+type SpecThrottlesListOptsBuilder interface {
+	ToSpecThrottlesListQuery() (string, error)
+}
+
+// ToSpecThrottlesListQuery is a method which to build a request query by the SpecThrottlesListOpts.
+func (opts SpecThrottlesListOpts) ToSpecThrottlesListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// ListSpecThrottles is a method to obtain an array of one or more special throttling policies
+// according to the query parameters.
+func ListSpecThrottles(client *golangsdk.ServiceClient, instanceId, policyId string,
+	opts SpecThrottlesListOptsBuilder) pagination.Pager {
+	url := specRootURL(client, instanceId, policyId)
+	if opts != nil {
+		query, err := opts.ToSpecThrottlesListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return SpecThrottlePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// DeleteSpecThrottle is a method to delete an existing special throttling policy.
+func DeleteSpecThrottle(client *golangsdk.ServiceClient, instanceId, policyId, strategyId string) (r DeleteResult) {
+	_, r.Err = client.Delete(specResourceURL(client, instanceId, policyId, strategyId), nil)
+	return
+}

--- a/openstack/apigw/v2/throttles/results.go
+++ b/openstack/apigw/v2/throttles/results.go
@@ -85,3 +85,60 @@ func ExtractPolicies(r pagination.Page) ([]ThrottlingPolicy, error) {
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
+
+// SpecThrottle is a struct that represents the result of CreateSpecThrottle, UpdateSpecThrottle and
+// ListSpecThrottles methods.
+type SpecThrottle struct {
+	// Maximum number of times the excluded object can access an API within the throttling period.
+	CallLimits int `json:"call_limits"`
+	// Name of the app to which the excluded request throttling configuration applies.
+	AppName string `json:"app_name"`
+	// Name of an app or a tenant to which the excluded request throttling configuration applies.
+	ObjectName string `json:"object_name"`
+	// ID of an object specified in the excluded request throttling configuration.
+	ObjectId string `json:"object_id"`
+	// Request throttling policy ID.
+	ThrottleId string `json:"throttle_id"`
+	// Time when the excluded request throttling configuration is created.
+	ApplyTime string `json:"apply_time"`
+	// Excluded request throttling configuration ID.
+	ID string `json:"id"`
+	// ID of the app to which the excluded request throttling configuration applies.
+	AppId string `json:"app_id"`
+	// Excluded object type, which can be APP or USER.
+	ObjectType string `json:"object_type"`
+}
+
+// The SpecThrottleResult represents the base result of the each special throttling polciy methods.
+type SpecThrottleResult struct {
+	commonResult
+}
+
+// The CreateSpecThrottleResult represents the result of the CreateSpecThrottle method.
+type CreateSpecThrottleResult struct {
+	SpecThrottleResult
+}
+
+// The UpdateSpecThrottleResult represents the result of the UpdateSpecThrottle method.
+type UpdateSpecThrottleResult struct {
+	SpecThrottleResult
+}
+
+// Extract is a method which to extract the response to a special throttling policy.
+func (r SpecThrottleResult) Extract() (*SpecThrottle, error) {
+	var s SpecThrottle
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// The SpecThrottlePage represents the result of a List operation.
+type SpecThrottlePage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractSpecThrottles its Extract method to interpret it as a special throttling policy array.
+func ExtractSpecThrottles(r pagination.Page) ([]SpecThrottle, error) {
+	var s []SpecThrottle
+	err := r.(SpecThrottlePage).Result.ExtractIntoSlicePtr(&s, "throttle_specials")
+	return s, err
+}

--- a/openstack/apigw/v2/throttles/testing/fixtures.go
+++ b/openstack/apigw/v2/throttles/testing/fixtures.go
@@ -46,6 +46,38 @@ const (
 		}
 	]
 }`
+
+	expectedSpecCreateResponse = `
+{
+	"app_id": "ba985f3d4fd347c3aee686fd749659fc",
+	"app_name": "terraform_app",
+	"apply_time": "2021-07-21T06:48:03.618383329Z",
+	"call_limits": 30,
+	"id": "aec8d27e3e034f4293bc766942ed60fd",
+	"object_id": "ba985f3d4fd347c3aee686fd749659fc",
+	"object_name": "terraform_app",
+	"object_type": "APP",
+	"throttle_id": "c481043838f64bcd82c7b0c38907d59d"
+}`
+
+	expectedSpecListResponse = `
+{
+	"throttle_specials": [
+		{
+			"app_id": "ba985f3d4fd347c3aee686fd749659fc",
+			"app_name": "terraform_app",
+			"apply_time": "2021-07-21T06:48:03.618383329Z",
+			"call_limits": 30,
+			"id": "aec8d27e3e034f4293bc766942ed60fd",
+			"object_id": "ba985f3d4fd347c3aee686fd749659fc",
+			"object_name": "terraform_app",
+			"object_type": "APP",
+			"throttle_id": "c481043838f64bcd82c7b0c38907d59d"
+		}
+	],
+	"size": 1,
+	"total": 1
+}`
 )
 
 var (
@@ -96,6 +128,46 @@ var (
 			Id:             "c481043838f64bcd82c7b0c38907d59d",
 		},
 	}
+
+	specThrottleCreateOpts = &throttles.SpecThrottleCreateOpts{
+		CallLimits: 30,
+		ObjectId:   "ba985f3d4fd347c3aee686fd749659fc",
+		ObjectType: "APP",
+	}
+
+	expectedSpecCreateResponseData = &throttles.SpecThrottle{
+		AppId:      "ba985f3d4fd347c3aee686fd749659fc",
+		AppName:    "terraform_app",
+		ApplyTime:  "2021-07-21T06:48:03.618383329Z",
+		CallLimits: 30,
+		ID:         "aec8d27e3e034f4293bc766942ed60fd",
+		ObjectId:   "ba985f3d4fd347c3aee686fd749659fc",
+		ObjectName: "terraform_app",
+		ObjectType: "APP",
+		ThrottleId: "c481043838f64bcd82c7b0c38907d59d",
+	}
+
+	specThrottleListOpts = &throttles.SpecThrottlesListOpts{
+		AppName: "terraform_app",
+	}
+
+	expectedSpecListResponseData = []throttles.SpecThrottle{
+		{
+			AppId:      "ba985f3d4fd347c3aee686fd749659fc",
+			AppName:    "terraform_app",
+			ApplyTime:  "2021-07-21T06:48:03.618383329Z",
+			CallLimits: 30,
+			ID:         "aec8d27e3e034f4293bc766942ed60fd",
+			ObjectId:   "ba985f3d4fd347c3aee686fd749659fc",
+			ObjectName: "terraform_app",
+			ObjectType: "APP",
+			ThrottleId: "c481043838f64bcd82c7b0c38907d59d",
+		},
+	}
+
+	specThrottleUpdateOpts = &throttles.SpecThrottleUpdateOpts{
+		CallLimits: 30,
+	}
 )
 
 func handleV2ThrottlingPolicyCreate(t *testing.T) {
@@ -143,6 +215,53 @@ func handleV2ThrottlingPolicyUpdate(t *testing.T) {
 
 func handleV2ThrottlingPolicyDelete(t *testing.T) {
 	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles/c481043838f64bcd82c7b0c38907d59d",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNoContent)
+		})
+}
+
+func handleV2SpecThrottlingPolicyCreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles/c481043838f64bcd82c7b0c38907d59d/"+
+		"throttle-specials",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedSpecCreateResponse)
+		})
+}
+
+func handleV2SpecThrottlingPolicyList(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles/c481043838f64bcd82c7b0c38907d59d/"+
+		"throttle-specials",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedSpecListResponse)
+		})
+}
+
+func handleV2SpecThrottlingPolicyUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles/c481043838f64bcd82c7b0c38907d59d/"+
+		"throttle-specials/aec8d27e3e034f4293bc766942ed60fd",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedSpecCreateResponse)
+		})
+}
+
+func handleV2SpecThrottlingPolicyDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/6da953fe33d44650a067e43a4593368b/throttles/c481043838f64bcd82c7b0c38907d59d/"+
+		"throttle-specials/aec8d27e3e034f4293bc766942ed60fd",
 		func(w http.ResponseWriter, r *http.Request) {
 			th.TestMethod(t, r, "DELETE")
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)

--- a/openstack/apigw/v2/throttles/testing/requests_test.go
+++ b/openstack/apigw/v2/throttles/testing/requests_test.go
@@ -62,3 +62,48 @@ func TestDeleteV2ThrottlingPolicy(t *testing.T) {
 		"c481043838f64bcd82c7b0c38907d59d").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestCreateV2SpecThrottlingPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2SpecThrottlingPolicyCreate(t)
+
+	actual, err := throttles.CreateSpecThrottle(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"c481043838f64bcd82c7b0c38907d59d", specThrottleCreateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedSpecCreateResponseData, actual)
+}
+
+func TestListV2SpecThrottlingPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2SpecThrottlingPolicyList(t)
+
+	pages, err := throttles.ListSpecThrottles(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"c481043838f64bcd82c7b0c38907d59d", specThrottleListOpts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := throttles.ExtractSpecThrottles(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedSpecListResponseData, actual)
+}
+
+func TestUpdateV2SpecThrottlingPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2SpecThrottlingPolicyUpdate(t)
+
+	actual, err := throttles.UpdateSpecThrottle(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"c481043838f64bcd82c7b0c38907d59d", "aec8d27e3e034f4293bc766942ed60fd", specThrottleUpdateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedSpecCreateResponseData, actual)
+}
+
+func TestDeleteV2SpecThrottlingPolicy(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2SpecThrottlingPolicyDelete(t)
+
+	err := throttles.DeleteSpecThrottle(client.ServiceClient(), "6da953fe33d44650a067e43a4593368b",
+		"c481043838f64bcd82c7b0c38907d59d", "aec8d27e3e034f4293bc766942ed60fd").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/apigw/v2/throttles/urls.go
+++ b/openstack/apigw/v2/throttles/urls.go
@@ -17,3 +17,11 @@ func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
 func resourceURL(c *golangsdk.ServiceClient, instanceId, policyId string) string {
 	return c.ServiceURL(buildRootPath(instanceId), policyId)
 }
+
+func specRootURL(c *golangsdk.ServiceClient, instanceId, policyId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), policyId, "throttle-specials")
+}
+
+func specResourceURL(c *golangsdk.ServiceClient, instanceId, policyId, strategyId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), policyId, "throttle-specials", strategyId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- In order to support APIG service through terraform, the special request throttling policy sdk needs to be added.
- The APIG contains:
  - Dedicated instance
  - Application
  - Group
  - Environment
    - Environment variables
  - API
    - ACL
    - Request throttling policy
    - **Special request throttling policy**
    - Custom Authorizer
    - Responses
  - VPC Channel
  - Domains
  - ...
- The special throttling policy can limit specific applications or IAM users from calling API.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. Add special throttling policy to throttles sdk:
  a. Create
  b. Update
  c. List
  d. Delete
2. Related method test supported.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2ThrottlingPolicy
--- PASS: TestCreateV2ThrottlingPolicy (0.00s)
=== RUN   TestGetV2ThrottlingPolicy
--- PASS: TestGetV2ThrottlingPolicy (0.00s)
=== RUN   TestListV2ThrottlingPolicy
--- PASS: TestListV2ThrottlingPolicy (0.00s)
=== RUN   TestUpdateV2ThrottlingPolicy
--- PASS: TestUpdateV2ThrottlingPolicy (0.00s)
=== RUN   TestDeleteV2ThrottlingPolicy
--- PASS: TestDeleteV2ThrottlingPolicy (0.00s)
=== RUN   TestCreateV2SpecThrottlingPolicy
--- PASS: TestCreateV2SpecThrottlingPolicy (0.00s)
=== RUN   TestListV2SpecThrottlingPolicy
--- PASS: TestListV2SpecThrottlingPolicy (0.00s)
=== RUN   TestUpdateV2SpecThrottlingPolicy
--- PASS: TestUpdateV2SpecThrottlingPolicy (0.00s)
=== RUN   TestDeleteV2SpecThrottlingPolicy
--- PASS: TestDeleteV2SpecThrottlingPolicy (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/throttles/testing   0.048s
```
