### PR TITLE
identity: update format of custom policy statement

### DIFF
--- a/openstack/identity/v3.0/policies/requests.go
+++ b/openstack/identity/v3.0/policies/requests.go
@@ -14,6 +14,7 @@ func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	return
 }
 
+// List retrieves all custom policies.
 func List(client *golangsdk.ServiceClient) pagination.Pager {
 	pager := pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
 		return RolePage{pagination.LinkedPageBase{PageResult: r}}
@@ -29,16 +30,18 @@ type CreateOptsBuilder interface {
 	ToPolicyCreateMap() (map[string]interface{}, error)
 }
 
+// Policy contains the content of a custom policy.
 type Policy struct {
 	Version   string      `json:"Version" required:"true"`
 	Statement []Statement `json:"Statement" required:"true"`
 }
 
+// Statement represents the Statement of a custom policy.
 type Statement struct {
-	Action    []string                       `json:"Action" required:"true"`
-	Effect    string                         `json:"Effect" required:"true"`
-	Condition map[string]map[string][]string `json:"Condition,omitempty"`
-	Resource  []string                       `json:"Resource,omitempty"`
+	Action    []string               `json:"Action" required:"true"`
+	Effect    string                 `json:"Effect" required:"true"`
+	Condition map[string]interface{} `json:"Condition,omitempty"`
+	Resource  interface{}            `json:"Resource,omitempty"`
 }
 
 // CreateOpts provides options used to create a policy.


### PR DESCRIPTION
update role.policy.Statement.Resource to interafce{}, then
the object can be compatible with cloud services and agencies.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

