### PR TITLE
New rds database securities sdk support

### DIFF
--- a/openstack/rds/v3/securities/requests.go
+++ b/openstack/rds/v3/securities/requests.go
@@ -1,0 +1,110 @@
+package securities
+
+import "github.com/huaweicloud/golangsdk"
+
+// SSLOpts is a struct which will be used to config the SSL (Secure Sockets Layer).
+type SSLOpts struct {
+	// Specifies whether to enable SSL.
+	//   true: SSL is enabled.
+	//   false: SSL is disabled.
+	SSLEnable *bool `json:"ssl_option" required:"true"`
+}
+
+// SSLOptsBuilder is an interface which to support request body build of
+// the ssl configuration of the specifies database.
+type SSLOptsBuilder interface {
+	ToSSLOptsMap() (map[string]interface{}, error)
+}
+
+// ToSSLOptsMap is a method which to build a request body by the SSLOpts.
+func (opts SSLOpts) ToSSLOptsMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UpdateSSL is a method to enable or disable the SSL.
+func UpdateSSL(client *golangsdk.ServiceClient, instanceId string, opts SSLOptsBuilder) (r SSLUpdateResult) {
+	b, err := opts.ToSSLOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(rootURL(client, instanceId, "ssl"), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// PortOpts is a struct which will be used to config the secure sockets layer.
+type PortOpts struct {
+	// Specifies the port number.
+	// The MySQL port number ranges from 1024 to 65535, excluding 12017 and 33071.
+	Port int `json:"port" required:"true"`
+}
+
+// PortOptsBuilder is an interface which to support request body build of
+// the port configuration of the specifies database.
+type PortOptsBuilder interface {
+	ToPortOptsMap() (map[string]interface{}, error)
+}
+
+// ToPortOptsMap is a method which to build a request body by the DBPortOpts.
+func (opts PortOpts) ToPortOptsMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UpdatePort is a method to update the port of the database.
+func UpdatePort(client *golangsdk.ServiceClient, instanceId string, opts PortOptsBuilder) (r commonResult) {
+	b, err := opts.ToPortOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(rootURL(client, instanceId, "port"), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// SecGroupOpts is a struct which will be used to update the specifies security group.
+type SecGroupOpts struct {
+	// Specifies the security group ID.
+	SecurityGroupId string `json:"security_group_id" required:"true"`
+}
+
+// SecGroupOptsBuilder is an interface which to support request body build of the security group updation.
+type SecGroupOptsBuilder interface {
+	ToSecGroupOptsMap() (map[string]interface{}, error)
+}
+
+// ToSecGroupOptsMap is a method which to build a request body by the SecGroupOpts.
+func (opts SecGroupOpts) ToSecGroupOptsMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UpdateSecGroup is a method to update the security group which the database belongs.
+func UpdateSecGroup(client *golangsdk.ServiceClient, instanceId string, opts SecGroupOptsBuilder) (r commonResult) {
+	b, err := opts.ToSecGroupOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(rootURL(client, instanceId, "security-group"), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}

--- a/openstack/rds/v3/securities/results.go
+++ b/openstack/rds/v3/securities/results.go
@@ -1,0 +1,34 @@
+package securities
+
+import "github.com/huaweicloud/golangsdk"
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// SSLUpdateResult represents a result of the ConfigureSSL method.
+type SSLUpdateResult struct {
+	golangsdk.ErrResult
+}
+
+// DBPortUpdateResult represents a result of the UpdateDBPort method.
+type DBPortUpdateResult struct {
+	commonResult
+}
+
+// SecGroupUpdateResult represents a result of the UpdateSecGroup method.
+type SecGroupUpdateResult struct {
+	commonResult
+}
+
+// WorkFlow is a struct that represents the result of database updation.
+type WorkFlow struct {
+	// Indicates the workflow ID.
+	WorkflowId string `json:"workflowId"`
+}
+
+func (r commonResult) Extract() (*WorkFlow, error) {
+	var s WorkFlow
+	err := r.ExtractInto(&s)
+	return &s, err
+}

--- a/openstack/rds/v3/securities/testing/fixtures.go
+++ b/openstack/rds/v3/securities/testing/fixtures.go
@@ -1,0 +1,73 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/rds/v3/securities"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedEnableSSLResponse = `{}`
+
+	expectedUpdateResponse = `
+{
+	"workflowId": "e982d9d7-d96f-4d25-a591-b6be03c93081"
+}
+`
+)
+
+var (
+	sslOpts = securities.SSLOpts{
+		SSLEnable: golangsdk.Enabled,
+	}
+
+	portOpts = securities.PortOpts{
+		Port: 3309,
+	}
+
+	secGroupOpts = securities.SecGroupOpts{
+		SecurityGroupId: "71aa11f4-7d6f-479c-b1b4-123f31412e21",
+	}
+
+	expectedGetResponseData = &securities.WorkFlow{
+		WorkflowId: "e982d9d7-d96f-4d25-a591-b6be03c93081",
+	}
+)
+
+func handleV2DatabaseSSLUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/fda30974248d449e9dbdce8ae65d5ba0in01/ssl",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedUpdateResponse)
+		})
+}
+
+func handleV2DatabasePortUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/fda30974248d449e9dbdce8ae65d5ba0in01/port",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedUpdateResponse)
+		})
+}
+
+func handleV2SecurityGroupUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/fda30974248d449e9dbdce8ae65d5ba0in01/security-group",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedUpdateResponse)
+		})
+}

--- a/openstack/rds/v3/securities/testing/requests_test.go
+++ b/openstack/rds/v3/securities/testing/requests_test.go
@@ -1,0 +1,40 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/rds/v3/securities"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestUpdateV2DatabaseSSL(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2DatabaseSSLUpdate(t)
+
+	err := securities.UpdateSSL(client.ServiceClient(), "fda30974248d449e9dbdce8ae65d5ba0in01", sslOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestUpdateV2DatabasePort(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2DatabasePortUpdate(t)
+
+	actual, err := securities.UpdatePort(client.ServiceClient(), "fda30974248d449e9dbdce8ae65d5ba0in01",
+		portOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestUpdateV2SecurityGroup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2SecurityGroupUpdate(t)
+
+	actual, err := securities.UpdateSecGroup(client.ServiceClient(), "fda30974248d449e9dbdce8ae65d5ba0in01",
+		secGroupOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}

--- a/openstack/rds/v3/securities/urls.go
+++ b/openstack/rds/v3/securities/urls.go
@@ -1,0 +1,7 @@
+package securities
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, instanceId, path string) string {
+	return c.ServiceURL("instances", instanceId, path)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To support database update, the sdk are missing database methods as follows:
- SSL enable and disable method
- update database port method
- update security group method

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. support database port update
2. support security group relate update
3. support ssl enable and disable
```

## Acceptance Steps Performed
```
go test -v -run Test=== RUN   TestUpdateV2DatabaseSSL
--- PASS: TestUpdateV2DatabaseSSL (0.00s)
=== RUN   TestUpdateV2DatabasePort
--- PASS: TestUpdateV2DatabasePort (0.00s)
=== RUN   TestUpdateV2SecurityGroup
--- PASS: TestUpdateV2SecurityGroup (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/rds/v3/securities/testing    0.012s
```