### PR TITLE
Add new API sdk for APIG v2

### DIFF
--- a/openstack/apigw/v2/apis/requests.go
+++ b/openstack/apigw/v2/apis/requests.go
@@ -1,0 +1,477 @@
+package apis
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// APIOpts is a struct which will be used to create a new API or update an existing API.
+type APIOpts struct {
+	// ID of the API group to which the API belongs.
+	GroupId string `json:"group_id" required:"true"`
+	// API name, which can contain 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name" required:"true"`
+	// API type. The valid types are as following:
+	//   1: public API
+	//   2: private API
+	Type int `json:"type" required:"true"`
+	// Request protocol. The valid protocols are as following:
+	//   HTTP.
+	//   HTTPS (default).
+	//   BOTH: The API can be accessed through both HTTP and HTTPS.
+	ReqProtocol string `json:"req_protocol" required:"true"`
+	// Request method. The valid values are GET,  POST,  PUT,  DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method" required:"true"`
+	// Request address, which can contain a maximum of 512 characters request parameters enclosed with brackets ({}).
+	// For example, /getUserInfo/{userId}.
+	// The request address can contain special characters, such as asterisks (), percent signs (%), hyphens (-), and
+	// underscores (_) and must comply with URI specifications.
+	// The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+	ReqURI string `json:"req_uri" required:"true"`
+	// Security authentication mode. The valid modes are as following:
+	//   NONE
+	//   APP
+	//   IAM
+	//   AUTHORIZER
+	AuthType string `json:"auth_type" required:"true"`
+	// Backend type. The valid types are as following:
+	//   HTTP: web backend.
+	//   FUNCTION: FunctionGraph backend.
+	//   MOCK: Mock backend.
+	BackendType string `json:"backend_type" required:"true"`
+	// API version. The maximum length of version string is 16.
+	Version *string `json:"version,omitempty"`
+	// Security authentication parameter.
+	AuthOpt *AuthOpt `json:"auth_opt,omitempty"`
+	// Indicates whether CORS is supported. The valid values are as following:
+	//   TRUE: supported.
+	//   FALSE: not supported (default).
+	Cors *bool `json:"cors,omitempty"`
+	// Route matching mode.  The valid modes are as following:
+	//   SWA: prefix match
+	//   NORMAL: exact match (default).
+	MatchMode string `json:"match_mode,omitempty"`
+	// Description of the API, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// API request body, which can be an example request body, media type, or parameters.
+	// Ensure that the request body does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	BodyDescription *string `json:"body_remark,omitempty"`
+	// Example response for a successful request. Ensure that the response does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	ResultNormalSample *string `json:"result_normal_sample,omitempty"`
+	// Example response for a failed request. Ensure that the response does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	ResultFailureSample *string `json:"result_failure_sample,omitempty"`
+	// ID of the frontend custom authorizer.
+	AuthorizerId string `json:"authorizer_id,omitempty"`
+	// List of tags. The length of the tags list is range from 1 to 128.
+	// The value can contain only letters, digits, and underscores (_), and must start with a letter.
+	Tags []string `json:"tags,omitempty"`
+	// Group response ID.
+	ResponseId string `json:"response_id,omitempty"`
+	// Request parameters.
+	ReqParams []ReqParamBase `json:"req_params,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamBase `json:"backend_params,omitempty"`
+	// Mock backend details.
+	MockInfo *Mock `json:"mock_info,omitempty"`
+	// FunctionGraph backend details.
+	FuncInfo *FuncGraph `json:"func_info,omitempty"`
+	// Web backend details.
+	WebInfo *Web `json:"backend_api,omitempty"`
+	// Mock policy backends.
+	PolicyMocks []PolicyMock `json:"policy_mocks,omitempty"`
+	// FunctionGraph policy backends.
+	PolicyFunctions []PolicyFuncGraph `json:"policy_functions,omitempty"`
+	// Web policy backends.
+	PolicyWebs []PolicyWeb `json:"policy_https,omitempty"`
+}
+
+// AuthOpt is an object which will be build up an APIG application authorization.
+type AuthOpt struct {
+	// Indicates whether AppCode authentication is enabled. The valid types are as following:
+	//   DISABLE: AppCode authentication is disabled (default).
+	//   HEADER: AppCode authentication is enabled and the AppCode is located in the header.
+	// This parameter is valid only if auth_type is set to App.
+	AppCodeAuthType string `json:"app_code_auth_type,omitempty"`
+}
+
+// Mock is an object which will be build up a mock backend.
+type Mock struct {
+	// Description about the backend, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// Response.
+	ResultContent *string `json:"result_content,omitempty"`
+	// Function version Ensure that the version does not exceed 64 characters.
+	Version string `json:"version,omitempty"`
+	// Backend custom authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+}
+
+// FuncGraph is an object which will be build up a function graph backend.
+type FuncGraph struct {
+	// Function URN.
+	FunctionUrn string `json:"function_urn" required:"true"`
+	// Invocation mode. The valid modes are as following:
+	//   async: asynchronous
+	//   sync: synchronous
+	InvocationType string `json:"invocation_type" required:"true"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout" required:"true"`
+	// Backend custom authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// Description about the backend, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// Function version.
+	// Maximum: 64
+	Version string `json:"version,omitempty"`
+}
+
+// Web is an object which will be build up a http backend.
+type Web struct {
+	// Request method. The valid methods are GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method" required:"true"`
+	// Request protocol. The valid protocols are HTTP and HTTPS
+	ReqProtocol string `json:"req_protocol" required:"true"`
+	// Request address, which can contain a maximum of 512 characters request parameters enclosed with brackets ({}).
+	// For example, /getUserInfo/{userId}.
+	// The request address can contain special characters, such as asterisks (*), percent signs (%), hyphens (-), and
+	// underscores (_) and must comply with URI specifications.
+	// The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+	ReqURI string `json:"req_uri" required:"true"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout" required:"true"`
+	// Backend custom authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// Backend service address which consists of a domain name or IP address and a port number, with not more than 255
+	// characters. It must be in the format "Host name:Port number", for example, apig.example.com:7443.
+	// If the port number is not specified, the default HTTPS port 443 or the default HTTP port 80 is used.
+	// The backend service address can contain environment variables, each starting with a letter and consisting of
+	// 3 to 32 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	DomainURL string `json:"url_domain,omitempty"`
+	// Description, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// Web backend version, which can contain a maximum of 16 characters.
+	Version *string `json:"version,omitempty"`
+	// Indicates whether to enable two-way authentication.
+	ClientSslEnable *bool `json:"enable_client_ssl,omitempty"`
+	// VPC channel details. This parameter is required if vpc_channel_status is set to 1.
+	VpcChannelInfo *VpcChannel `json:"vpc_channel_info,omitempty"`
+	// Indicates whether to use a VPC channel. The valid values are as following:
+	//   1: (A VPC channel is used).
+	//   2: (No VPC channel is used).
+	VpcChannelStatus int `json:"vpc_channel_status,omitempty"`
+}
+
+// VpcChannel is an object which will be build up a vpc channel.
+type VpcChannel struct {
+	// VPC channel ID.
+	VpcChannelId string `json:"vpc_channel_id" required:"true"`
+	// Proxy host.
+	VpcChannelProxyHost string `json:"vpc_channel_proxy_host,omitempty"`
+}
+
+// ReqParamBase is an object which will be build up a front-end request parameter.
+type ReqParamBase struct {
+	// The parameter name, which contain of 1 to 32 characters and start with a letter.
+	// Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed.
+	Name string `json:"name" required:"true"`
+	// Parameter type. The valid types are as following:
+	//   STRING
+	//   NUMBER
+	Type string `json:"type" required:"true"`
+	// Parameter location. The valid modes are as following:
+	//   PATH
+	//   QUERY
+	//   HEADER
+	Location string `json:"location" required:"true"`
+	// Default value.
+	DefaultValue *string `json:"default_value,omitempty"`
+	// Example value.
+	SampleValue string `json:"sample_value,omitempty"`
+	// Indicates whether the parameter is required. The valid values are 1 (yes) and 2 (no).
+	// The value of this parameter is 1 if Location is set to PATH, and 2 if Location is set to another value.
+	Required int `json:"required,omitempty"`
+	// Indicates whether validity check is enabled. The valid modes are as following:
+	//   1: enabled.
+	//   2: disabled (default).
+	ValidEnable int `json:"valid_enable,omitempty"`
+	// Description about the backend, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+	// Enumerated value.
+	Enumerations *string `json:"enumerations,omitempty"`
+	// Minimum value.
+	// This parameter is valid when type is set to NUMBER.
+	MinNum *int `json:"min_num,omitempty"`
+	// Maximum value.
+	// This parameter is valid when type is set to NUMBER.
+	MaxNum *int `json:"max_num,omitempty"`
+	// Minimum length.
+	// This parameter is valid when type is set to STRING.
+	MinSize *int `json:"min_size,omitempty"`
+	// Maximum length.
+	// This parameter is valid when type is set to STRING.
+	MaxSize *int `json:"max_size,omitempty"`
+	// Indicates whether to transparently transfer the parameter. The valid values are 1 (yes) and 2 (no).
+	PassThrough string `json:"pass_through,omitempty"`
+}
+
+// PolicyMock is an object which will be build up a backend policy of the mock.
+type PolicyMock struct {
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Effective mode of the backend policy. The valid modes are as following:
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Backend name, which consists of 3 to 64 characters and must start with a letter and can contain letters, digits,
+	// and underscores (_).
+	Name string `json:"name" required:"true"`
+	// Authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamBase `json:"backend_params,omitempty"`
+	// Response.
+	ResultContent string `json:"result_content,omitempty"`
+}
+
+// PolicyFuncGraph is an object which will be build up a backend policy of the function graph.
+type PolicyFuncGraph struct {
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Effective mode of the backend policy.
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Function URN.
+	FunctionUrn string `json:"function_urn" required:"true"`
+	// Invocation mode. The valid modes are as following:
+	//   async: asynchronous
+	//   sync: synchronous
+	InvocationType string `json:"invocation_type" required:"true"`
+	// The backend name consists of 3 to 64 characters, which must start with a letter and can contain letters, digits,
+	// and underscores (_).
+	Name string `json:"name" required:"true"`
+	// Authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamBase `json:"backend_params,omitempty"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout,omitempty"`
+	// Function version Ensure that the version does not exceed 64 characters.
+	Version string `json:"version,omitempty"`
+}
+
+// PolicyWeb is an object which will be build up a backend policy of the http.
+type PolicyWeb struct {
+	// Request protocol. The value can be HTTP or HTTPS.
+	ReqProtocol string `json:"req_protocol" required:"true"`
+	// Request method. The valid methods are GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method" required:"true"`
+	// Request address, which can contain request parameters enclosed with brackets ({}).
+	// For example, /getUserInfo/{userId}. The request address can contain special characters, such as asterisks (),
+	// percent signs (%), hyphens (-), and underscores (_). It can contain a maximum of 512 characters and must comply
+	// with URI specifications.
+	// The request address can contain environment variables, each starting with a letter and consisting of 3 to 32
+	// characters. Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+	// The request address must comply with URI specifications.
+	ReqURI string `json:"req_uri" required:"true"`
+	// Effective mode of the backend policy. The valid modes are as following:
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Backend name, which contains of 3 to 64, must start with a letter and can contain letters, digits, and
+	// underscores (_).
+	Name string `json:"name" required:"true"`
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Backend parameters.
+	BackendParams []BackendParamBase `json:"backend_params,omitempty"`
+	// Authorizer ID.
+	AuthorizerId *string `json:"authorizer_id,omitempty"`
+	// VPC channel details. This parameter is required if vpc_channel_status is set to 1.
+	VpcChannelInfo *VpcChannel `json:"vpc_channel_info,omitempty"`
+	// Indicates whether to use a VPC channel. The valid value are as following:
+	//   1: A VPC channel is used.
+	//   2: No VPC channel is used.
+	VpcChannelStatus int `json:"vpc_channel_status,omitempty"`
+	// Endpoint of the policy backend.
+	// An endpoint consists of a domain name or IP address and a port number, with not more than 255 characters.
+	// It must be in the format "Domain name:Port number", for example, apig.example.com:7443.
+	// If the port number is not specified, the default HTTPS port 443 or the default HTTP port 80 is used.
+	// The endpoint can contain environment variables, each starting with letter and consisting of 3 to 32 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	DomainURL string `json:"url_domain,omitempty"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout,omitempty"`
+}
+
+// BackendParamBase is an object which will be build up a back-end parameter.
+type BackendParamBase struct {
+	// Parameter type. The valid types are as following:
+	//   REQUEST: Backend parameter.
+	//   CONSTANT: Constant parameter.
+	//   SYSTEM: System parameter.
+	Origin string `json:"origin" required:"true"`
+	// Parameter name, which can contains 1 to 32 characters, must start with a letter and can only contain letters,
+	// digits, hyphens (-), underscores (_) and periods (.).
+	Name string `json:"name" required:"true"`
+	// Parameter location. The valid values are PATH, QUERY and HEADER.
+	Location string `json:"location" required:"true"`
+	// Parameter value, which can contain a maximum of 255 characters. If the origin type is REQUEST, the value of this parameter is the parameter name in req_params.
+	// If the origin type is CONSTANT, the value is a constant.
+	// If the origin type is SYSTEM, the value is a system parameter name. System parameters include gateway parameters, frontend authentication parameters, and backend authentication parameters. You can set the frontend or backend authentication parameters after enabling custom frontend or backend authentication.
+	// The gateway parameters are as follows:
+	//   $context.sourceIp: source IP address of the API caller.
+	//   $context.stage: deployment environment in which the API is called.
+	//   $context.apiId: API ID.
+	//   $context.appId: ID of the app used by the API caller.
+	//   $context.requestId: request ID generated when the API is called.
+	//   $context.serverAddr: address of the gateway server.
+	//   $context.serverName: name of the gateway server.
+	//   $context.handleTime: time when the API request is processed.
+	//   $context.providerAppId: ID of the app used by the API owner. This parameter is currently not supported.
+	// Frontend authentication parameter: prefixed with "$context.authorizer.frontend.". For example, to return "aaa" upon successful custom authentication, set this parameter to "$context.authorizer.frontend.aaa".
+	// Backend authentication parameter: prefixed with "$context.authorizer.backend.". For example, to return "aaa" upon successful custom authentication, set this parameter to "$context.authorizer.backend.aaa".
+	Value string `json:"value" required:"true"`
+	// Description, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description *string `json:"remark,omitempty"`
+}
+
+// APIConditionBase is an object which will be build up a policy condition.
+type APIConditionBase struct {
+	// Policy type. The valid types are as following:
+	//   param: input parameter
+	//   source: source IP address
+	ConditionOrigin string `json:"condition_origin" required:"true"`
+	// Condition value.
+	ConditionValue string `json:"condition_value" required:"true"`
+	// Input parameter name. This parameter is required if the policy type is param.
+	ReqParamName string `json:"req_param_name,omitempty"`
+	// Policy condition. The valid values are as following:
+	//   exact: exact match
+	//   enum: enumeration
+	//   pattern: regular expression
+	// This parameter is required if the policy type is param.
+	ConditionType string `json:"condition_type,omitempty"`
+}
+
+// APIOptsBuilder is an interface which to support request body build of the API creation and updation.
+type APIOptsBuilder interface {
+	ToAPIOptsMap() (map[string]interface{}, error)
+}
+
+// ToAPIOptsMap is a method which to build a request body by the APIOpts.
+func (opts APIOpts) ToAPIOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method by which to create function that create a new custom API.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts APIOptsBuilder) (r CreateResult) {
+	reqBody, err := opts.ToAPIOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client, instanceId), reqBody, &r.Body, nil)
+	return
+}
+
+// Update is a method to update an existing custom API.
+func Update(client *golangsdk.ServiceClient, instanceId, appId string, opts APIOptsBuilder) (r UpdateResult) {
+	reqBody, err := opts.ToAPIOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, instanceId, appId), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtain the specified API according to the instanceId and API ID.
+func Get(client *golangsdk.ServiceClient, instanceId, apiId string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, instanceId, apiId), &r.Body, nil)
+	return
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// API ID.
+	ID string `q:"id"`
+	// API name.
+	Name string `q:"name"`
+	// API group ID.
+	GroupId string `q:"group_id"`
+	// Request protocol.
+	ReqProtocol string `q:"req_protocol"`
+	// Request method.
+	ReqMethod string `q:"req_method"`
+	// Request path.
+	ReqURI string `q:"req_uri"`
+	// Security authentication mode.
+	AuthType string `q:"auth_type"`
+	// ID of the environment in which the API has been published.
+	EnvId string `q:"env_id"`
+	// API type.
+	Type int `q:"type"`
+	// Offset from which the query starts.
+	// If the offset is less than 0, the value is automatically converted to 0. Default to 0.
+	Offset int `q:"offset"`
+	// Number of items displayed on each page. The range of number is form 1 to 500, default to 20.
+	Limit int `q:"limit"`
+	// Parameter name (name or req_uri) for exact matching.
+	PreciseSearch string `q:"precise_search"`
+}
+
+// ListOptsBuilder is an interface which to support request query build of the API search.
+type ListOptsBuilder interface {
+	ToListOptsQuery() (string, error)
+}
+
+// ToListOptsQuery is a method which to build a request query by the ListOpts.
+func (opts ListOpts) ToListOptsQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method to obtain an array of one or more APIs according to the query parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client, instanceId)
+	if opts != nil {
+		query, err := opts.ToListOptsQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return APIPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Delete is a method to delete an existing custom API.
+func Delete(client *golangsdk.ServiceClient, instanceId, apiId string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, instanceId, apiId), nil)
+	return
+}

--- a/openstack/apigw/v2/apis/results.go
+++ b/openstack/apigw/v2/apis/results.go
@@ -1,0 +1,354 @@
+package apis
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents a result of the Get method.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents a result of the Update method.
+type UpdateResult struct {
+	commonResult
+}
+
+// APIResp is a struct that represents the result of Create, Update, Get and List methods.
+type APIResp struct {
+	// API name which can contains of 3 to 64 characters, starting with a letter.
+	// Only letters, digits, and underscores (_) are allowed.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Name string `json:"name"`
+	// API type. The valid types are as following:
+	//   1: public API
+	//   2: private API
+	Type int `json:"type"`
+	// API version which can contains maximum of 16 characters.
+	Version string `json:"version"`
+	// Request protocol.
+	//   HTTP
+	//   HTTPS (default)
+	//   BOTH: The API can be accessed through both HTTP and HTTPS.
+	ReqProtocol string `json:"req_protocol"`
+	// Request method. The valid values are GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method"`
+	// Request address, which can contain request parameters enclosed with brackets ({}). For example,
+	//   /getUserInfo/{userId}.
+	// The request address can contain special characters, such as asterisks (*), percent signs (%), hyphens (-), and underscores (_). It can contain a maximum of 512 characters and must comply with URI specifications.
+	// The request address must comply with URI specifications.
+	ReqURI string `json:"req_uri"`
+	// Security authentication mode. The valid values are as following:
+	//   NONE
+	//   APP
+	//   IAM
+	//   AUTHORIZER
+	AuthType string `json:"auth_type"`
+	// Security authentication parameter.
+	AuthOpt AuthOpt `json:"auth_opt"`
+	// Indicates whether CORS is supported.
+	// TRUE: supported
+	// FALSE: not supported (default).
+	Cors bool `json:"cors"`
+	// Route matching mode.
+	//   SWA: prefix match
+	//   NORMAL: exact match (default).
+	MatchMode string `json:"match_mode"`
+	// Backend type. The valid types are as following:
+	//   HTTP: web backend
+	//   FUNCTION: FunctionGraph backend
+	//   MOCK: Mock backend
+	BackendType string `json:"backend_type"`
+	// Description of the API, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark"`
+	// ID of the API group to which the API belongs.
+	GroupId string `json:"group_id"`
+	// API request body, which can be an example request body, media type, or parameters.
+	// Ensure that the request body does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	BodyDescription string `json:"body_remark"`
+	// Example response for a successful request. Ensure that the response does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	ResultNormalSample string `json:"result_normal_sample"`
+	// Example response for a failed request. Ensure that the response does not exceed 20,480 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	ResultFailureSample string `json:"result_failure_sample"`
+	// ID of the frontend custom authorizer.
+	AuthorizerId string `json:"authorizer_id"`
+	// Tags.
+	Tags []string `json:"tags"`
+	// Group response ID.
+	ResponseId string `json:"response_id"`
+	// API ID.
+	ID string `json:"id"`
+	// API status. 1: valid
+	Status int `json:"status"`
+	// Indicates whether to enable orchestration.
+	ArrangeNecessary int `json:"arrange_necessary"`
+	// Time when the API is registered.
+	RegisterTime string `json:"register_time"`
+	// Time when the API was last modified.
+	UpdateTime string `json:"update_time"`
+	// Name of the API group to which the API belongs.
+	GroupName string `json:"group_name"`
+	// Version of the API group to which the API belongs.
+	// The default value is V1. Other versions are not supported.
+	GroupVersion string `json:"group_version"`
+	// ID of the environment in which the API has been published.
+	// If there are multiple publication records, separate the environment IDs with vertical bars (|).
+	RunEnvId string `json:"run_env_id"`
+	// Name of the environment in which the API has been published.
+	// If there are multiple publication records, separate the environment names with vertical bars (|).
+	RunEnvName string `json:"run_env_name"`
+	// Publication record ID.
+	// You can separate multiple publication record IDs with vertical bars (|).
+	PublishId string `json:"publish_id"`
+	// FunctionGraph backend details.
+	FuncInfo FuncGraph `json:"func_info"`
+	// Mock backend details.
+	MockInfo Mock `json:"mock_info"`
+	// Web backend details.
+	WebInfo Web `json:"backend_api"`
+	// Request parameters.
+	ReqParams []ReqParamResp `json:"req_params"`
+	// Backend parameters.
+	BackendParams []BackendParamResp `json:"backend_params"`
+	// Mock policy backends.
+	PolicyMocks []PolicyMockResp `json:"policy_mocks"`
+	// FunctionGraph policy backends.
+	PolicyFunctions []PolicyFuncGraphResp `json:"policy_functions"`
+	// Web policy backends.
+	PolicyWebs []PolicyWebResp `json:"policy_https"`
+	// The following four parameters are only provided by the response of the API Versions.
+	//   SlDomain
+	//   SlDomains
+	//   VersionId
+	//   PublishTime.
+	// Subdomain name that API Gateway automatically allocates to the API group.
+	SlDomain string `json:"sl_domain"`
+	// Subdomain names that API Gateway automatically allocates to the API group.
+	SlDomains []string `json:"sl_domains"`
+	// API version ID.
+	VersionId string `json:"version_id"`
+	//Time when the API version is published.
+	PublishTime string `json:"publish_time"`
+}
+
+// ReqParamResp is an object struct that represents the elements of the front-end request parameter.
+type ReqParamResp struct {
+	// The parameter name, which contain of 1 to 32 characters and start with a letter.
+	// Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed.
+	Name string `json:"name"`
+	// Parameter type. The valid types are as following:
+	//   STRING
+	//   NUMBER
+	Type string `json:"type"`
+	// Parameter location. The valid modes are as following:
+	//   PATH
+	//   QUERY
+	//   HEADER
+	Location string `json:"location"`
+	// Default value.
+	DefaultValue string `json:"default_value"`
+	// Example value.
+	SampleValue string `json:"sample_value"`
+	// Indicates whether the parameter is required. The valid values are 1 (yes) and 2 (no).
+	// The value of this parameter is 1 if Location is set to PATH, and 2 if Location is set to another value.
+	Required int `json:"required"`
+	// Indicates whether validity check is enabled. The valid modes are as following:
+	// 1: enabled.
+	// 2: disabled (default).
+	ValidEnable int `json:"valid_enable"`
+	// Description about the backend, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark"`
+	// Enumerated value.
+	Enumerations string `json:"enumerations"`
+	// Minimum value.
+	// This parameter is valid when type is set to NUMBER.
+	MinNum int `json:"min_num"`
+	// Maximum value.
+	// This parameter is valid when type is set to NUMBER.
+	MaxNum int `json:"max_num"`
+	// Minimum length.
+	// This parameter is valid when type is set to STRING.
+	MinSize int `json:"min_size"`
+	// Maximum length.
+	// This parameter is valid when type is set to STRING.
+	MaxSize int `json:"max_size"`
+	// Indicates whether to transparently transfer the parameter. The valid values are 1 (yes) and 2 (no).
+	PassThrough int `json:"pass_through"`
+	// Parameter ID.
+	// Notes: This parameter is used for response.
+	ID string `json:"id"`
+}
+
+// BackendParamResp is an object struct that represents the elements of the back-end parameter.
+type BackendParamResp struct {
+	// Parameter type. The valid types are as following:
+	//   REQUEST: Backend parameter.
+	//   CONSTANT: Constant parameter.
+	//   SYSTEM: System parameter.
+	Origin string `json:"origin"`
+	// Parameter name, which can contains 1 to 32 characters, must start with a letter and can only contain letters, digits, hyphens (-), underscores (_),
+	// and periods (.).
+	Name string `json:"name"`
+	// Description, which can contain a maximum of 255 characters.
+	// Chinese characters must be in UTF-8 or Unicode format.
+	Description string `json:"remark"`
+	// Parameter location. The valid values are PATH, QUERY and HEADER.
+	Location string `json:"location"`
+	// Parameter value, which can contain a maximum of 255 characters.
+	// If the origin type is REQUEST, the value of this parameter is the parameter name in req_params.
+	// If the origin type is CONSTANT, the value is a constant.
+	// If the origin type is SYSTEM, the value is a system parameter name.
+	// System parameters include gateway parameters, front-end authentication parameters, and back-end authentication
+	// parameters. You can set the frontend or backend authentication parameters after enabling custom frontend or
+	// backend authentication.
+	// The gateway parameters are as follows:
+	//   $context.sourceIp: source IP address of the API caller.
+	//   $context.stage: deployment environment in which the API is called.
+	//   $context.apiId: API ID.
+	//   $context.appId: ID of the app used by the API caller.
+	//   $context.requestId: request ID generated when the API is called.
+	//   $context.serverAddr: address of the gateway server.
+	//   $context.serverName: name of the gateway server.
+	//   $context.handleTime: time when the API request is processed.
+	//   $context.providerAppId: ID of the app used by the API owner. This parameter is currently not supported.
+	// Frontend authentication parameter: prefixed with "$context.authorizer.frontend.".
+	// For example, to return "aaa" upon successful custom authentication, set this parameter to
+	// "$context.authorizer.frontend.aaa".
+	// Backend authentication parameter: prefixed with "$context.authorizer.backend.".
+	// For example, to return "aaa" upon successful custom authentication, set this parameter to
+	// "$context.authorizer.backend.aaa".
+	Value string `json:"value"`
+	// ID of the the specifies request parameter.
+	ReqParamId string `json:"req_param_id"`
+}
+
+// PolicyMockResp is an object struct that represents the back-end policy of mock.
+type PolicyMockResp struct {
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Effective mode of the backend policy. The valid modes are as following:
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Backend name, which consists of 3 to 64 characters and must start with a letter and can contain letters, digits,
+	// and underscores (_).
+	Name string `json:"name" required:"true"`
+	// Authorizer ID.
+	AuthorizerId string `json:"authorizer_id,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamResp `json:"backend_params,omitempty"`
+	// Response.
+	ResultContent string `json:"result_content,omitempty"`
+}
+
+// PolicyFuncGraphResp is an object struct that represents the back-end policy of function graph.
+type PolicyFuncGraphResp struct {
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Effective mode of the backend policy.
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Function URN.
+	FunctionUrn string `json:"function_urn" required:"true"`
+	// Invocation mode. The valid modes are as following:
+	//   async: asynchronous
+	//   sync: synchronous
+	InvocationType string `json:"invocation_type" required:"true"`
+	// The backend name, which can consists of 3 to 64 characters and must start with a letter and can contain letters,
+	// digits, and underscores (_).
+	Name string `json:"name" required:"true"`
+	// Authorizer ID.
+	AuthorizerId string `json:"authorizer_id,omitempty"`
+	// Backend parameters.
+	BackendParams []BackendParamResp `json:"backend_params,omitempty"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout,omitempty"`
+	// Function version Ensure that the version does not exceed 64 characters.
+	Version string `json:"version,omitempty"`
+}
+
+// PolicyWebResp is an object struct that represents the back-end policy of http and https.
+type PolicyWebResp struct {
+	// Request protocol. The value can be HTTP or HTTPS.
+	ReqProtocol string `json:"req_protocol" required:"true"`
+	// Request method. The valid methods are GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS and ANY.
+	ReqMethod string `json:"req_method" required:"true"`
+	// Request address, which can contain request parameters enclosed with brackets ({}). For example,
+	//   /getUserInfo/{userId}.
+	// The request address can contain special characters, such as asterisks (), percent signs (%), hyphens (-), and
+	// underscores (_). It can contain a maximum of 512 characters and must comply with URI specifications.
+	// The request address can contain environment variables, each starting with a letter and consisting of 3 to 32
+	// characters. Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+	// The request address must comply with URI specifications.
+	ReqURI string `json:"req_uri" required:"true"`
+	// Endpoint of the policy backend.
+	// An endpoint consists of a domain name or IP address and a port number, with not more than 255 characters.
+	// It must be in the format "Domain name:Port number", for example, apig.example.com:7443.
+	// If the port number is not specified, the default HTTPS port 443 or the default HTTP port 80 is used.
+	// The endpoint can contain environment variables, each starting with letter and consisting of 3 to 32 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	DomainURL string `json:"url_domain,omitempty"`
+	// Timeout, in ms, which allowed for API Gateway to request the backend service.
+	// The valid value is range from 1 to 600,000.
+	Timeout int `json:"timeout,omitempty"`
+	// Effective mode of the backend policy. The valid modes are as following:
+	//   ALL: All conditions are met.
+	//   ANY: Any condition is met.
+	EffectMode string `json:"effect_mode" required:"true"`
+	// Backend name, which contains of 3 to 64 and must start with a letter and can contain letters, digits, and
+	// underscores (_).
+	Name string `json:"name" required:"true"`
+	// Backend parameters.
+	BackendParams []BackendParamResp `json:"backend_params,omitempty"`
+	// Policy conditions.
+	Conditions []APIConditionBase `json:"conditions" required:"true"`
+	// Authorizer ID.
+	AuthorizerId string `json:"authorizer_id,omitempty"`
+	// VPC channel details. This parameter is required if vpc_channel_status is set to 1.
+	VpcChannelInfo VpcChannel `json:"vpc_channel_info,omitempty"`
+	// Indicates whether to use a VPC channel. The valid value are as following:
+	//   1: A VPC channel is used.
+	//   2: No VPC channel is used.
+	VpcChannelEnable int `json:"vpc_channel_status,omitempty"`
+}
+
+// Extract is a method to extract an response struct.
+func (r commonResult) Extract() (*APIResp, error) {
+	var s APIResp
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// APIPage represents the api pages of the List operation.
+type APIPage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractApis is a method to extract an response struct list.
+func ExtractApis(r pagination.Page) ([]APIResp, error) {
+	var s []APIResp
+	err := r.(APIPage).Result.ExtractIntoSlicePtr(&s, "apis")
+	return s, err
+}
+
+// DeleteResult represents a result of the Delete method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/apigw/v2/apis/testing/fixtures.go
+++ b/openstack/apigw/v2/apis/testing/fixtures.go
@@ -1,0 +1,383 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedCreateResponse = `
+{
+	"arrange_necessary": 2,
+	"auth_opt": {
+		"app_code_auth_type": "DISABLE"
+	},
+	"auth_type": "AUTHORIZER",
+	"authorizer_id": "8b9c7d67ca144a5da7bc9cbccedfe753",
+	"backend_api": {
+		"enable_client_ssl": false,
+		"req_method": "GET",
+		"req_protocol": "HTTP",
+		"req_uri": "/backend/users",
+		"timeout": 6000,
+		"url_domain": "69bb5628fce741a1b901b08cde7b814d",
+		"vpc_channel_info": {
+			"vpc_channel_id": "69bb5628fce741a1b901b08cde7b814d"
+		},
+		"vpc_channel_status": 1
+	},
+	"backend_params": [
+		{
+			"location": "HEADER",
+			"name": "X-User-Name",
+			"origin": "SYSTEM",
+			"value": "$context.authorizer.frontend.user_name"
+		}
+	],
+	"backend_type": "HTTP",
+	"cors": false,
+	"group_id": "c6e46c49a6734c918262a16c3c1a3a13",
+	"group_name": "terraform_test",
+	"group_version": "V1",
+	"id": "cded6d80fc9f442c9842eaf854f10525",
+	"match_mode": "NORMAL",
+	"name": "terraform_test",
+	"register_time": "2021-08-05T03:33:35.360020923Z",
+	"req_method": "POST",
+	"req_protocol": "HTTP",
+	"req_uri": "/terraform/users",
+	"status": 1,
+	"type": 2,
+	"update_time": "2021-08-05T03:33:35.360021226Z"
+}`
+
+	expectedGetResponse = `
+{
+	"arrange_necessary": 2,
+	"auth_opt": {
+		"app_code_auth_type": "DISABLE"
+	},
+	"auth_type": "AUTHORIZER",
+	"authorizer_id": "8b9c7d67ca144a5da7bc9cbccedfe753",
+	"backend_api": {
+		"enable_client_ssl": false,
+		"req_method": "GET",
+		"req_protocol": "HTTP",
+		"req_uri": "/backend/users",
+		"timeout": 6000,
+		"url_domain": "69bb5628fce741a1b901b08cde7b814d",
+		"vpc_channel_info": {
+			"vpc_channel_id": "69bb5628fce741a1b901b08cde7b814d"
+		},
+		"vpc_channel_status": 1
+	},
+	"backend_params": [
+		{
+		  "location": "HEADER",
+		  "name": "X-User-Name",
+		  "origin": "SYSTEM",
+		  "value": "$context.authorizer.frontend.user_name"
+		}
+	],
+	"backend_type": "HTTP",
+	"cors": false,
+	"group_id": "c6e46c49a6734c918262a16c3c1a3a13",
+	"group_name": "terraform_test",
+	"group_version": "V1",
+	"id": "cded6d80fc9f442c9842eaf854f10525",
+	"match_mode": "NORMAL",
+	"name": "terraform_test",
+	"register_time": "2021-08-05T03:33:35.360020923Z",
+	"req_method": "POST",
+	"req_protocol": "HTTP",
+	"req_uri": "/terraform/users",
+	"status": 1,
+	"type": 2,
+	"update_time": "2021-08-05T03:33:35Z"
+}
+`
+
+	expectedListResponse = `
+{
+	"total": 1,
+	"size": 1,
+	"apis": [
+		{
+			"arrange_necessary": 2,
+			"auth_opt": {
+				"app_code_auth_type": "DISABLE"
+			},
+			"auth_type": "AUTHORIZER",
+			"authorizer_id": "8b9c7d67ca144a5da7bc9cbccedfe753",
+			"backend_api": {
+				"enable_client_ssl": false,
+				"req_method": "GET",
+				"req_protocol": "HTTP",
+				"req_uri": "/backend/users",
+				"timeout": 6000,
+				"url_domain": "69bb5628fce741a1b901b08cde7b814d",
+				"vpc_channel_info": {
+					"vpc_channel_id": "69bb5628fce741a1b901b08cde7b814d"
+				},
+				"vpc_channel_status": 1
+			},
+			"backend_params": [
+				{
+				  "location": "HEADER",
+				  "name": "X-User-Name",
+				  "origin": "SYSTEM",
+				  "value": "$context.authorizer.frontend.user_name"
+				}
+			],
+			"backend_type": "HTTP",
+			"cors": false,
+			"group_id": "c6e46c49a6734c918262a16c3c1a3a13",
+			"group_name": "terraform_test",
+			"group_version": "V1",
+			"id": "cded6d80fc9f442c9842eaf854f10525",
+			"match_mode": "NORMAL",
+			"name": "terraform_test",
+			"register_time": "2021-08-05T03:33:35.360020923Z",
+			"req_method": "POST",
+			"req_protocol": "HTTP",
+			"req_uri": "/terraform/users",
+			"status": 1,
+			"type": 2,
+			"update_time": "2021-08-05T03:33:35Z"
+		}
+	]
+}`
+)
+
+var (
+	createOpts = apis.APIOpts{
+		GroupId:      "c6e46c49a6734c918262a16c3c1a3a13",
+		Type:         2,
+		AuthType:     "AUTHORIZER",
+		AuthorizerId: "8b9c7d67ca144a5da7bc9cbccedfe753",
+		Cors:         golangsdk.Disabled,
+		MatchMode:    "NORMAL",
+		Name:         "terraform_test",
+		ReqURI:       "/terraform/users",
+		ReqMethod:    "POST",
+		ReqProtocol:  "HTTP",
+		BackendType:  "HTTP",
+		WebInfo: &apis.Web{
+			ClientSslEnable: golangsdk.Disabled,
+			ReqMethod:       "POST",
+			ReqProtocol:     "HTTP",
+			ReqURI:          "/backend/users",
+			Timeout:         6000,
+			VpcChannelInfo: &apis.VpcChannel{
+				VpcChannelId: "69bb5628fce741a1b901b08cde7b814d",
+			},
+			VpcChannelStatus: 1,
+		},
+		BackendParams: []apis.BackendParamBase{
+			{
+				Location: "HEADER",
+				Name:     "X-User-Name",
+				Origin:   "SYSTEM",
+				Value:    "$context.authorizer.frontend.user_name",
+			},
+		},
+	}
+
+	expectedCreateResponseData = &apis.APIResp{
+		ArrangeNecessary: 2,
+		AuthType:         "AUTHORIZER",
+		AuthorizerId:     "8b9c7d67ca144a5da7bc9cbccedfe753",
+		AuthOpt: apis.AuthOpt{
+			AppCodeAuthType: "DISABLE",
+		},
+		WebInfo: apis.Web{
+			ClientSslEnable: golangsdk.Disabled,
+			ReqMethod:       "GET",
+			ReqProtocol:     "HTTP",
+			ReqURI:          "/backend/users",
+			Timeout:         6000,
+			DomainURL:       "69bb5628fce741a1b901b08cde7b814d",
+			VpcChannelInfo: &apis.VpcChannel{
+				VpcChannelId: "69bb5628fce741a1b901b08cde7b814d",
+			},
+			VpcChannelStatus: 1,
+		},
+		BackendParams: []apis.BackendParamResp{
+			{
+				Location: "HEADER",
+				Name:     "X-User-Name",
+				Origin:   "SYSTEM",
+				Value:    "$context.authorizer.frontend.user_name",
+			},
+		},
+		BackendType:  "HTTP",
+		Cors:         false,
+		GroupId:      "c6e46c49a6734c918262a16c3c1a3a13",
+		GroupName:    "terraform_test",
+		GroupVersion: "V1",
+		ID:           "cded6d80fc9f442c9842eaf854f10525",
+		MatchMode:    "NORMAL",
+		Name:         "terraform_test",
+		RegisterTime: "2021-08-05T03:33:35.360020923Z",
+		ReqMethod:    "POST",
+		ReqProtocol:  "HTTP",
+		ReqURI:       "/terraform/users",
+		Status:       1,
+		Type:         2,
+		UpdateTime:   "2021-08-05T03:33:35.360021226Z",
+	}
+
+	expectedGetResponseData = &apis.APIResp{
+		ArrangeNecessary: 2,
+		AuthType:         "AUTHORIZER",
+		AuthorizerId:     "8b9c7d67ca144a5da7bc9cbccedfe753",
+		AuthOpt: apis.AuthOpt{
+			AppCodeAuthType: "DISABLE",
+		},
+		WebInfo: apis.Web{
+			ClientSslEnable: golangsdk.Disabled,
+			ReqMethod:       "GET",
+			ReqProtocol:     "HTTP",
+			ReqURI:          "/backend/users",
+			Timeout:         6000,
+			DomainURL:       "69bb5628fce741a1b901b08cde7b814d",
+			VpcChannelInfo: &apis.VpcChannel{
+				VpcChannelId: "69bb5628fce741a1b901b08cde7b814d",
+			},
+			VpcChannelStatus: 1,
+		},
+		BackendParams: []apis.BackendParamResp{
+			{
+				Location: "HEADER",
+				Name:     "X-User-Name",
+				Origin:   "SYSTEM",
+				Value:    "$context.authorizer.frontend.user_name",
+			},
+		},
+		BackendType:  "HTTP",
+		Cors:         false,
+		GroupId:      "c6e46c49a6734c918262a16c3c1a3a13",
+		GroupName:    "terraform_test",
+		GroupVersion: "V1",
+		ID:           "cded6d80fc9f442c9842eaf854f10525",
+		MatchMode:    "NORMAL",
+		Name:         "terraform_test",
+		RegisterTime: "2021-08-05T03:33:35.360020923Z",
+		ReqMethod:    "POST",
+		ReqProtocol:  "HTTP",
+		ReqURI:       "/terraform/users",
+		Status:       1,
+		Type:         2,
+		UpdateTime:   "2021-08-05T03:33:35Z",
+	}
+
+	listOpts = &apis.ListOpts{
+		Name: "terraform_test",
+	}
+
+	expectedListResponseData = []apis.APIResp{
+		{
+			ArrangeNecessary: 2,
+			AuthType:         "AUTHORIZER",
+			AuthorizerId:     "8b9c7d67ca144a5da7bc9cbccedfe753",
+			AuthOpt: apis.AuthOpt{
+				AppCodeAuthType: "DISABLE",
+			},
+			WebInfo: apis.Web{
+				ClientSslEnable: golangsdk.Disabled,
+				ReqMethod:       "GET",
+				ReqProtocol:     "HTTP",
+				ReqURI:          "/backend/users",
+				Timeout:         6000,
+				DomainURL:       "69bb5628fce741a1b901b08cde7b814d",
+				VpcChannelInfo: &apis.VpcChannel{
+					VpcChannelId: "69bb5628fce741a1b901b08cde7b814d",
+				},
+				VpcChannelStatus: 1,
+			},
+			BackendParams: []apis.BackendParamResp{
+				{
+					Location: "HEADER",
+					Name:     "X-User-Name",
+					Origin:   "SYSTEM",
+					Value:    "$context.authorizer.frontend.user_name",
+				},
+			},
+			BackendType:  "HTTP",
+			Cors:         false,
+			GroupId:      "c6e46c49a6734c918262a16c3c1a3a13",
+			GroupName:    "terraform_test",
+			GroupVersion: "V1",
+			ID:           "cded6d80fc9f442c9842eaf854f10525",
+			MatchMode:    "NORMAL",
+			Name:         "terraform_test",
+			RegisterTime: "2021-08-05T03:33:35.360020923Z",
+			ReqMethod:    "POST",
+			ReqProtocol:  "HTTP",
+			ReqURI:       "/terraform/users",
+			Status:       1,
+			Type:         2,
+			UpdateTime:   "2021-08-05T03:33:35Z",
+		},
+	}
+)
+
+func handleV2APICreate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/33fc92ffb7e749df952ecc7729d972bc/apis",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedCreateResponse)
+		})
+}
+
+func handleV2APIGet(t *testing.T) {
+	th.Mux.HandleFunc("/instances/33fc92ffb7e749df952ecc7729d972bc/apis/cded6d80fc9f442c9842eaf854f10525",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleV2APIList(t *testing.T) {
+	th.Mux.HandleFunc("/instances/33fc92ffb7e749df952ecc7729d972bc/apis",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedListResponse)
+		})
+}
+
+func handleV2APIUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/instances/33fc92ffb7e749df952ecc7729d972bc/apis/cded6d80fc9f442c9842eaf854f10525",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleV2APIDelete(t *testing.T) {
+	th.Mux.HandleFunc("/instances/33fc92ffb7e749df952ecc7729d972bc/apis/cded6d80fc9f442c9842eaf854f10525",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "DELETE")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNoContent)
+		})
+}

--- a/openstack/apigw/v2/apis/testing/requests_test.go
+++ b/openstack/apigw/v2/apis/testing/requests_test.go
@@ -1,0 +1,65 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateV2API(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2APICreate(t)
+
+	actual, err := apis.Create(client.ServiceClient(), "33fc92ffb7e749df952ecc7729d972bc",
+		createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestGetV2API(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2APIGet(t)
+
+	actual, err := apis.Get(client.ServiceClient(), "33fc92ffb7e749df952ecc7729d972bc",
+		"cded6d80fc9f442c9842eaf854f10525").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestListV2API(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2APIList(t)
+
+	pages, err := apis.List(client.ServiceClient(), "33fc92ffb7e749df952ecc7729d972bc",
+		listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := apis.ExtractApis(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV2API(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2APIUpdate(t)
+
+	actual, err := apis.Update(client.ServiceClient(), "33fc92ffb7e749df952ecc7729d972bc",
+		"cded6d80fc9f442c9842eaf854f10525", createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestDeleteV2API(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2APIDelete(t)
+
+	err := apis.Delete(client.ServiceClient(), "33fc92ffb7e749df952ecc7729d972bc",
+		"cded6d80fc9f442c9842eaf854f10525").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/apigw/v2/apis/urls.go
+++ b/openstack/apigw/v2/apis/urls.go
@@ -1,0 +1,21 @@
+package apis
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+const rootPath = "instances"
+
+func buildRootPath(instanceId string) string {
+	return fmt.Sprintf("instances/%s/apis", instanceId)
+}
+
+func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(buildRootPath(instanceId))
+}
+
+func resourceURL(c *golangsdk.ServiceClient, instanceId, apiId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), apiId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- In order to support APIG service through terraform, the API sdk needs to be added.
- The API sdk can support customer to create the API with APP (, IAM, NONE) authorization, web (, function graph and mock) backend and related backend policies.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. Add api sdk to apig v2:
  a. Create
  b. Update
  c. List
  d. Delete
2. Related method test supported.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2API
--- PASS: TestCreateV2API (0.00s)
=== RUN   TestGetV2API
--- PASS: TestGetV2API (0.00s)
=== RUN   TestListV2API
--- PASS: TestListV2API (0.00s)
=== RUN   TestUpdateV2API
--- PASS: TestUpdateV2API (0.00s)
=== RUN   TestDeleteV2API
--- PASS: TestDeleteV2API (0.00s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/apigw/v2/apis/testing        0.843s
```
