### PR TITLE
add dli queue scale

### DIFF
--- a/openstack/dli/v1/queues/requests.go
+++ b/openstack/dli/v1/queues/requests.go
@@ -67,6 +67,13 @@ type ListOpts struct {
 	Tags           string `q:"tags"`
 }
 
+type ActionOpts struct {
+	Action    string `json:"action" required:"true"` //Operations to be performed: restart; scale_out;scale_in
+	Force     bool   `json:"force,omitempty"`        //when action= restart,can Specifies whether to forcibly restart
+	CuCount   int    `json:"cu_count,omitempty"`     // Number of CUs to be scaled in or out.
+	QueueName string `json:"-" required:"true"`
+}
+
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
 type CreateOptsBuilder interface {
@@ -174,4 +181,15 @@ func Get(c *golangsdk.ServiceClient, queueName string) (r GetResult) {
 	}
 
 	return r
+}
+
+func ScaleOrRestart(c *golangsdk.ServiceClient, opts ActionOpts) (r PutResult) {
+	requstbody, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(ActionURL(c, opts.QueueName), requstbody, &r.Body, reqOpt)
+	return
 }

--- a/openstack/dli/v1/queues/results.go
+++ b/openstack/dli/v1/queues/results.go
@@ -110,3 +110,7 @@ type GetResult struct {
 type DeleteResult struct {
 	golangsdk.Result
 }
+
+type PutResult struct {
+	golangsdk.Result
+}

--- a/openstack/dli/v1/queues/testing/fixtures.go
+++ b/openstack/dli/v1/queues/testing/fixtures.go
@@ -62,12 +62,32 @@ var (
 	}
 )
 
+var (
+	mockScaleActionResponse = `
+	{
+		"queue_name": "tf_acc_test_dli_queue_h8yr3",
+		"result": true
+	}`
+)
+
+var queueName1 = "tf_acc_test_dli_queue_h8yr3"
+
 func handleList(t *testing.T) {
-	th.Mux.HandleFunc("/queues", func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/queues/", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, expectedListResponse)
+	})
+}
+
+func handleScale(t *testing.T) {
+	th.Mux.HandleFunc("/queues/"+queueName1+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, mockScaleActionResponse)
 	})
 }

--- a/openstack/dli/v1/queues/testing/requests_test.go
+++ b/openstack/dli/v1/queues/testing/requests_test.go
@@ -18,3 +18,18 @@ func TestList(t *testing.T) {
 	rt := listResult.Body.(*queues.ListResult)
 	th.AssertDeepEquals(t, expectedListResponseData, rt.Queues[0])
 }
+
+func TestScale(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	handleScale(t)
+
+	result := queues.ScaleOrRestart(client.ServiceClient(), queues.ActionOpts{
+		Action:    "scale_out",
+		CuCount:   16,
+		QueueName: queueName1,
+	})
+
+	th.AssertNoErr(t, result.Err)
+}

--- a/openstack/dli/v1/queues/urls.go
+++ b/openstack/dli/v1/queues/urls.go
@@ -4,6 +4,7 @@ import "github.com/huaweicloud/golangsdk"
 
 const (
 	resourcePath = "queues"
+	actionPath   = "action"
 )
 
 func createURL(c *golangsdk.ServiceClient) string {
@@ -16,4 +17,8 @@ func resourceURL(c *golangsdk.ServiceClient, queueName string) string {
 
 func queryAllURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
+}
+
+func ActionURL(c *golangsdk.ServiceClient, queueName string) string {
+	return c.ServiceURL(resourcePath, queueName, actionPath)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add dli queue scale

**Test**:

```Test
Running tool: /usr/local/go/bin/go test -timeout 30s -coverprofile=/tmp/vscode-goqx91yE/go-code-cover github.com/huaweicloud/golangsdk/openstack/dli/v1/queues/testing -v

=== RUN   TestList
--- PASS: TestList (0.00s)
=== RUN   TestScale
--- PASS: TestScale (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/huaweicloud/golangsdk/openstack/dli/v1/queues/testing	0.015s	coverage: 100.0% of statements

```

