### PR TITLE
Refactor trigger and add update method

### DIFF
--- a/openstack/fgs/v2/trigger/requests.go
+++ b/openstack/fgs/v2/trigger/requests.go
@@ -5,54 +5,105 @@ import (
 	"github.com/huaweicloud/golangsdk/pagination"
 )
 
+// CreateOpts is a struct which will be used to create a new trigger.
+type CreateOpts struct {
+	// Trigger type, which support:
+	//   TIMER
+	//   APIG
+	//   CTS
+	//   DDS
+	//   DMS
+	//   DIS
+	//   LTS
+	//   OBS
+	//   KAFKA
+	//   SMN
+	TriggerTypeCode string `json:"trigger_type_code" required:"true"`
+	// Trigger status, which support:
+	//   ACTIVE
+	//   DISABLED
+	TriggerStatus string `json:"trigger_status,omitempty"`
+	// Message code.
+	EventTypeCode string `json:"event_type_code" required:"true"`
+	// Event struct.
+	EventData map[string]interface{} `json:"event_data" required:"true"`
+}
+
+// CreateOptsBuilder is an interface used to support the construction of the request body for trigger creates.
 type CreateOptsBuilder interface {
 	ToCreateTriggerMap() (map[string]interface{}, error)
 }
 
-//Trigger struct
-type CreateOpts struct {
-	TriggerTypeCode string                 `json:"trigger_type_code" required:"true"`
-	EventTypeCode   string                 `json:"event_type_code" required:"true"`
-	EventData       map[string]interface{} `json:"event_data" required:"true"`
-}
-
+// ToCreateTriggerMap is a method which to build a request body by the CreateOpts.
 func (opts CreateOpts) ToCreateTriggerMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-//Creating a Trigger
-func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder, functionUrn string) (r CreateResult) {
+// Create is a method to create trigger through function urn and CreateOpts.
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder, urn string) (r CreateResult) {
 	b, err := opts.ToCreateTriggerMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = c.Post(createURL(c, functionUrn), b, &r.Body, nil)
+	_, r.Err = c.Post(createURL(c, urn), b, &r.Body, nil)
 	return
 }
 
-//Querying All Triggers of a Function
-func List(c *golangsdk.ServiceClient, functionUrn string) pagination.Pager {
-	url := listURL(c, functionUrn)
+// List is a method to obtain an array of one or more trigger for function graph according to the urn.
+func List(c *golangsdk.ServiceClient, urn string) pagination.Pager {
+	url := listURL(c, urn)
 	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return TriggerPage{pagination.SinglePageBase(r)}
 	})
 }
 
-//Querying the Information About a Trigger
-func Get(c *golangsdk.ServiceClient, functionUrn, triggerTypeCode, triggerId string) (r GetResult) {
-	_, r.Err = c.Get(getURL(c, functionUrn, triggerTypeCode, triggerId), &r.Body, &golangsdk.RequestOpts{OkCodes: []int{200}})
+// Get is a method to obtain a trigger through function urn, function code and trigger ID.
+func Get(c *golangsdk.ServiceClient, urn, triggerType, triggerId string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, urn, triggerType, triggerId), &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
 	return
 }
 
-//Deleting a Trigger
-func Delete(c *golangsdk.ServiceClient, functionUrn, triggerTypeCode, triggerId string) (r DeleteResult) {
-	_, r.Err = c.Delete(deleteURL(c, functionUrn, triggerTypeCode, triggerId), &golangsdk.RequestOpts{OkCodes: []int{204, 200}})
+// UpdateOpts is a struct which will be used to update existing trigger.
+type UpdateOpts struct {
+	TriggerStatus string `json:"trigger_status" required:"true"`
+}
+
+// UpdateOptsBuilder is an interface used to support the construction of the request body for trigger updates.
+type UpdateOptsBuilder interface {
+	ToUpdateTriggerMap() (map[string]interface{}, error)
+}
+
+// ToUpdateTriggerMap is a method which to build a request body by the UpdateOpts.
+func (opts UpdateOpts) ToUpdateTriggerMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update is a method to update existing trigger through function urn, function code, trigger ID and UpdateOpts.
+func Update(c *golangsdk.ServiceClient, opts UpdateOptsBuilder, urn, triggerType, triggerId string) (r UpdateResult) {
+	b, err := opts.ToUpdateTriggerMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, urn, triggerType, triggerId), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
 	return
 }
 
-//Deleting All Triggers of a Function
-func DeleteAll(c *golangsdk.ServiceClient, functionUrn string) (r DeleteResult) {
-	_, r.Err = c.Delete(deleteAllURL(c, functionUrn), nil)
+// Delete is a method to delete existing trigger.
+func Delete(c *golangsdk.ServiceClient, urn, triggerType, triggerId string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, urn, triggerType, triggerId), &golangsdk.RequestOpts{
+		OkCodes: []int{204, 200},
+	})
+	return
+}
+
+// DeleteAll is a method to delete all triggers from a function
+func DeleteAll(c *golangsdk.ServiceClient, urn string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteAllURL(c, urn), nil)
 	return
 }

--- a/openstack/fgs/v2/trigger/results.go
+++ b/openstack/fgs/v2/trigger/results.go
@@ -5,35 +5,40 @@ import (
 	"github.com/huaweicloud/golangsdk/pagination"
 )
 
-type TriggerPage struct {
-	pagination.SinglePageBase
-}
-
 type commonResult struct {
 	golangsdk.Result
 }
 
+// CreateResult represents a result of the Create method.
 type CreateResult struct {
 	commonResult
 }
 
-type DeleteResult struct {
-	golangsdk.ErrResult
-}
-
+// GetResult represents a result of the Update method.
 type GetResult struct {
 	commonResult
 }
 
+// UpdateResult represents a result of the Update method.
+type UpdateResult struct {
+	golangsdk.ErrResult
+}
+
+// DeleteResult represents a result of the Delete method.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+// Trigger is a struct that represents the result of Create and Get methods.
 type Trigger struct {
 	TriggerId       string                 `json:"trigger_id"`
 	TriggerTypeCode string                 `json:"trigger_type_code"`
 	EventData       map[string]interface{} `json:"event_data"`
-	EventTypeCode   string                 `json:"event_type_code,omitempty"`
-	Status          string                 `json:"trigger_status,omitempty"`
-	LastUpdatedTime string                 `json:"last_updated_time,omitempty"`
-	CreatedTime     string                 `json:"created_time,omitempty"`
-	LastError       string                 `json:"last_error,omitempty"`
+	EventTypeCode   string                 `json:"event_type_code"`
+	Status          string                 `json:"trigger_status"`
+	LastUpdatedTime string                 `json:"last_updated_time"`
+	CreatedTime     string                 `json:"created_time"`
+	LastError       string                 `json:"last_error"`
 }
 
 func (r commonResult) Extract() (*Trigger, error) {
@@ -42,6 +47,12 @@ func (r commonResult) Extract() (*Trigger, error) {
 	return &s, err
 }
 
+// TriggerPage represents the response pages of the List method.
+type TriggerPage struct {
+	pagination.SinglePageBase
+}
+
+// ExtractList is a method which to extract the response to a trigger list.
 func ExtractList(r pagination.Page) ([]Trigger, error) {
 	var s []Trigger
 	err := (r.(TriggerPage)).ExtractInto(&s)

--- a/openstack/fgs/v2/trigger/testing/fixtures.go
+++ b/openstack/fgs/v2/trigger/testing/fixtures.go
@@ -1,0 +1,142 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/fgs/v2/trigger"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+const (
+	expectedGetResponse = `
+{
+	"trigger_id": "971f9cff-5d29-42da-ba36-e4e2b9d26664",
+	"trigger_type_code": "TIMER",
+	"trigger_status": "ACTIVE",
+	"event_data": {
+		"name": "test",
+		"schedule": "1d",
+		"schedule_type": "Rate"
+	},
+	"last_updated_time": "2021-08-11T17:03:20+08:00",
+	"created_time": "2021-08-11T17:03:20+08:00"
+}`
+
+	expectedListResponse = `
+[
+	{
+		"trigger_id": "971f9cff-5d29-42da-ba36-e4e2b9d26664",
+		"trigger_type_code": "TIMER",
+		"trigger_status": "ACTIVE",
+		"event_data": {
+			"name": "test",
+			"schedule": "1d",
+			"schedule_type": "Rate"
+		},
+		"last_updated_time": "2021-08-11T17:03:20+08:00",
+		"created_time": "2021-08-11T17:03:20+08:00"
+	}
+]`
+)
+
+var (
+	createOpts = &trigger.CreateOpts{
+		TriggerTypeCode: "TIMER",
+		TriggerStatus:   "ACTIVE",
+		EventTypeCode:   "MessageCreated",
+		EventData: map[string]interface{}{
+			"name":          "test",
+			"schedule":      "1d",
+			"schedule_type": "Rate",
+		},
+	}
+
+	expectedGetResponseData = &trigger.Trigger{
+		CreatedTime:     "2021-08-11T17:03:20+08:00",
+		TriggerId:       "971f9cff-5d29-42da-ba36-e4e2b9d26664",
+		TriggerTypeCode: "TIMER",
+		EventData: map[string]interface{}{
+			"name":          "test",
+			"schedule":      "1d",
+			"schedule_type": "Rate",
+		},
+		Status:          "ACTIVE",
+		LastUpdatedTime: "2021-08-11T17:03:20+08:00",
+	}
+
+	expectedListResponseData = []trigger.Trigger{
+		{
+			CreatedTime:     "2021-08-11T17:03:20+08:00",
+			TriggerId:       "971f9cff-5d29-42da-ba36-e4e2b9d26664",
+			TriggerTypeCode: "TIMER",
+			EventData: map[string]interface{}{
+				"name":          "test",
+				"schedule":      "1d",
+				"schedule_type": "Rate",
+			},
+			Status:          "ACTIVE",
+			LastUpdatedTime: "2021-08-11T17:03:20+08:00",
+		},
+	}
+
+	updateOpts = trigger.UpdateOpts{
+		TriggerStatus: "ACTIVE",
+	}
+)
+
+func handleV2TriggerCreate(t *testing.T) {
+	th.Mux.HandleFunc("/fgs/triggers/urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedGetResponse)
+		})
+}
+
+func handleV2TriggerGet(t *testing.T) {
+	th.Mux.HandleFunc("/fgs/triggers/urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test"+
+		"/TIMER/971f9cff-5d29-42da-ba36-e4e2b9d26664", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedGetResponse)
+	})
+}
+
+func handleV2TriggerList(t *testing.T) {
+	th.Mux.HandleFunc("/fgs/triggers/urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedListResponse)
+		})
+}
+
+func handleV2TriggerUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/fgs/triggers/urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test"+
+		"/TIMER/971f9cff-5d29-42da-ba36-e4e2b9d26664", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedGetResponse)
+	})
+}
+
+func handleV2TriggerDelete(t *testing.T) {
+	th.Mux.HandleFunc("/fgs/triggers/urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test"+
+		"/TIMER/971f9cff-5d29-42da-ba36-e4e2b9d26664", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/openstack/fgs/v2/trigger/testing/requests_test.go
+++ b/openstack/fgs/v2/trigger/testing/requests_test.go
@@ -1,0 +1,67 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/golangsdk/openstack/fgs/v2/trigger"
+	th "github.com/huaweicloud/golangsdk/testhelper"
+	"github.com/huaweicloud/golangsdk/testhelper/client"
+)
+
+func TestCreateV2Trigger(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2TriggerCreate(t)
+
+	actual, err := trigger.Create(client.ServiceClient(), createOpts,
+		"urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestGetV2Trigger(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2TriggerGet(t)
+
+	actual, err := trigger.Get(client.ServiceClient(),
+		"urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test",
+		"TIMER", "971f9cff-5d29-42da-ba36-e4e2b9d26664").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedGetResponseData, actual)
+}
+
+func TestListV2Trigger(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2TriggerList(t)
+
+	pages, err := trigger.List(client.ServiceClient(),
+		"urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test").AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := trigger.ExtractList(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV2Trigger(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2TriggerUpdate(t)
+
+	err := trigger.Update(client.ServiceClient(), updateOpts,
+		"urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test",
+		"TIMER", "971f9cff-5d29-42da-ba36-e4e2b9d26664").ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestDeleteV2Trigger(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2TriggerDelete(t)
+
+	err := trigger.Delete(client.ServiceClient(),
+		"urn:fss:cn-north-4:0721565481a5d123f6e6c66a2115215a:function:default:test",
+		"TIMER", "971f9cff-5d29-42da-ba36-e4e2b9d26664").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/fgs/v2/trigger/urls.go
+++ b/openstack/fgs/v2/trigger/urls.go
@@ -20,9 +20,9 @@ func deleteAllURL(c *golangsdk.ServiceClient, functionUrn string) string {
 }
 
 func deleteURL(c *golangsdk.ServiceClient, functionUrn, triggerTypeCode, triggerId string) string {
-	return getURL(c, functionUrn, triggerTypeCode, triggerId)
+	return resourceURL(c, functionUrn, triggerTypeCode, triggerId)
 }
 
-func getURL(c *golangsdk.ServiceClient, functionUrn, triggerTypeCode, triggerId string) string {
+func resourceURL(c *golangsdk.ServiceClient, functionUrn, triggerTypeCode, triggerId string) string {
 	return c.ServiceURL(FGS, TRIGGER, functionUrn, triggerTypeCode, triggerId)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- The trigger sdk missing update method.
- parameter name of the 'TriggerTypeStatus' is wrong.
- some arguments name are too long.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. refactor old trigger method:
  a. parameters naming.
  b. update parameter name 'TriggerTypeStatus' to 'TriggerStatus'.
2. add update method.
3. support related method tests.
```

## Acceptance Steps Performed
```
go test -v -run Test
=== RUN   TestCreateV2Trigger
--- PASS: TestCreateV2Trigger (0.00s)
=== RUN   TestGetV2Trigger
--- PASS: TestGetV2Trigger (0.00s)
=== RUN   TestListV2Trigger
--- PASS: TestListV2Trigger (0.01s)
=== RUN   TestUpdateV2Trigger
--- PASS: TestUpdateV2Trigger (0.00s)
=== RUN   TestDeleteV2Trigger
--- PASS: TestDeleteV2Trigger (0.02s)
PASS
ok      github.com/huaweicloud/golangsdk/openstack/fgs/v2/trigger/testing       0.127s
```
