### PR TITLE
ecs: change the map value of SubJob.Entities to interface

### DIFF
--- a/openstack/ecs/v1/cloudservers/results_job.go
+++ b/openstack/ecs/v1/cloudservers/results_job.go
@@ -59,7 +59,7 @@ type SubJob struct {
 	FailReason string `json:"fail_reason"`
 
 	// Specifies the object of the task.
-	Entities map[string]string `json:"entities"`
+	Entities map[string]interface{} `json:"entities"`
 }
 
 type JobResult struct {
@@ -91,7 +91,7 @@ func WaitForJobSuccess(client *golangsdk.ServiceClient, secs int, jobID string) 
 			return true, nil
 		}
 		if job.Status == "FAIL" {
-			err = fmt.Errorf("Job failed with code %s: %s.\n", job.ErrorCode, job.FailReason)
+			err = fmt.Errorf("Job failed with code %s: %s", job.ErrorCode, job.FailReason)
 			return false, err
 		}
 
@@ -107,10 +107,10 @@ func GetJobEntity(client *golangsdk.ServiceClient, jobID string, label string) (
 	}
 
 	if job.Status == "SUCCESS" {
-		if e := job.Entities.SubJobs[0].Entities[label]; e != "" {
+		if e, ok := job.Entities.SubJobs[0].Entities[label]; ok {
 			return e, nil
 		}
 	}
 
-	return nil, fmt.Errorf("Unexpected conversion error in GetJobEntity.")
+	return nil, fmt.Errorf("Unexpected conversion error in GetJobEntity")
 }


### PR DESCRIPTION
the response of SubJob.Entities includes:
server_id(string), nic_id(string) and attached_volume_ids([]string)

so, we update the map value to interface.

linked to: huaweicloud/terraform-provider-huaweicloud#1397

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

